### PR TITLE
Generate a GetItems method for list types

### DIFF
--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -45,6 +45,26 @@ func Managed() Object {
 	}
 }
 
+// ManagedList returns an Object matcher that returns true if the supplied
+// Object is a list of Crossplane managed resource.
+func ManagedList() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsItems().And(fields.IsSlice()).And(fields.HasFieldThat(
+				fields.IsTypeMeta().And(fields.IsEmbedded()),
+				fields.IsObjectMeta().And(fields.IsEmbedded()),
+				fields.IsSpec().And(fields.HasFieldThat(
+					fields.IsResourceSpec().And(fields.IsEmbedded()),
+				)),
+				fields.IsStatus().And(fields.HasFieldThat(
+					fields.IsResourceStatus().And(fields.IsEmbedded()),
+				)),
+			)),
+		)
+	}
+}
+
 // Class returns an Object matcher that returns true if the supplied Object is a
 // Crossplane resource class.
 func Class() Object {
@@ -54,6 +74,23 @@ func Class() Object {
 			fields.IsObjectMeta().And(fields.IsEmbedded()),
 			fields.IsSpecTemplate().And(fields.HasFieldThat(
 				fields.IsClassSpecTemplate().And(fields.IsEmbedded()),
+			)),
+		)
+	}
+}
+
+// ClassList returns an Object matcher that returns true if the supplied
+// Object is a list of Crossplane resource classes.
+func ClassList() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsItems().And(fields.IsSlice()).And(fields.HasFieldThat(
+				fields.IsTypeMeta().And(fields.IsEmbedded()),
+				fields.IsObjectMeta().And(fields.IsEmbedded()),
+				fields.IsSpecTemplate().And(fields.HasFieldThat(
+					fields.IsClassSpecTemplate().And(fields.IsEmbedded()),
+				)),
 			)),
 		)
 	}
@@ -70,6 +107,24 @@ func Claim() Object {
 				fields.IsResourceClaimSpec().And(fields.IsEmbedded()),
 			)),
 			fields.IsResourceClaimStatus(),
+		)
+	}
+}
+
+// ClaimList returns an Object matcher that returns true if the supplied
+// Object is a list of Crossplane resource claims.
+func ClaimList() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsItems().And(fields.IsSlice()).And(fields.HasFieldThat(
+				fields.IsTypeMeta().And(fields.IsEmbedded()),
+				fields.IsObjectMeta().And(fields.IsEmbedded()),
+				fields.IsSpec().And(fields.HasFieldThat(
+					fields.IsResourceClaimSpec().And(fields.IsEmbedded()),
+				)),
+				fields.IsResourceClaimStatus(),
+			)),
 		)
 	}
 }

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -303,7 +303,8 @@ func NewGetReclaimPolicy(receiver, runtime, field string) New {
 }
 
 // NewGetCredentialsSecretReference returns a NewMethod that writes a
-// GetCredentialsSecretReference method for the supplied Object to the supplied file.
+// GetCredentialsSecretReference method for the supplied Object to the supplied
+// file.
 func NewGetCredentialsSecretReference(receiver, runtime string) New {
 	return func(f *jen.File, o types.Object) {
 		f.Commentf("GetCredentialsSecretReference of this %s.", o.Name())
@@ -314,12 +315,58 @@ func NewGetCredentialsSecretReference(receiver, runtime string) New {
 }
 
 // NewSetCredentialsSecretReference returns a NewMethod that writes a
-// SetCredentialsSecretReference method for the supplied Object to the supplied file.
+// SetCredentialsSecretReference method for the supplied Object to the supplied
+// file.
 func NewSetCredentialsSecretReference(receiver, runtime string) New {
 	return func(f *jen.File, o types.Object) {
 		f.Commentf("SetCredentialsSecretReference of this %s.", o.Name())
 		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetCredentialsSecretReference").Params(jen.Id("r").Op("*").Qual(runtime, "SecretKeySelector")).Block(
 			jen.Id(receiver).Dot(fields.NameSpec).Dot("CredentialsSecretRef").Op("=").Id("r"),
+		)
+	}
+}
+
+// NewManagedGetItems returns a New that writes a GetItems method for the
+// supplied object to the supplied file.
+func NewManagedGetItems(receiver, resource string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetItems of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetItems").Params().Index().Qual(resource, "Managed").Block(
+			jen.Id("items").Op(":=").Make(jen.Index().Qual(resource, "Managed"), jen.Len(jen.Id(receiver).Dot("Items"))),
+			jen.For(jen.Id("i").Op(":=").Range().Id(receiver).Dot("Items")).Block(
+				jen.Id("items").Index(jen.Id("i")).Op("=").Op("&").Id(receiver).Dot("Items").Index(jen.Id("i")),
+			),
+			jen.Return(jen.Id("items")),
+		)
+	}
+}
+
+// NewClaimGetItems returns a New that writes a GetItems method for the supplied
+// object to the supplied file.
+func NewClaimGetItems(receiver, resource string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetItems of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetItems").Params().Index().Qual(resource, "Claim").Block(
+			jen.Id("items").Op(":=").Make(jen.Index().Qual(resource, "Claim"), jen.Len(jen.Id(receiver).Dot("Items"))),
+			jen.For(jen.Id("i").Op(":=").Range().Id(receiver).Dot("Items")).Block(
+				jen.Id("items").Index(jen.Id("i")).Op("=").Op("&").Id(receiver).Dot("Items").Index(jen.Id("i")),
+			),
+			jen.Return(jen.Id("items")),
+		)
+	}
+}
+
+// NewClassGetItems returns a New that writes a GetItems method for the supplied
+// object to the supplied file.
+func NewClassGetItems(receiver, resource string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetItems of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetItems").Params().Index().Qual(resource, "Class").Block(
+			jen.Id("items").Op(":=").Make(jen.Index().Qual(resource, "Class"), jen.Len(jen.Id(receiver).Dot("Items"))),
+			jen.For(jen.Id("i").Op(":=").Range().Id(receiver).Dot("Items")).Block(
+				jen.Id("items").Index(jen.Id("i")).Op("=").Op("&").Id(receiver).Dot("Items").Index(jen.Id("i")),
+			),
+			jen.Return(jen.Id("items")),
 		)
 	}
 }

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -375,3 +375,66 @@ func (t *Type) GetReclaimPolicy() runtime.ReclaimPolicy {
 		t.Errorf("NewGetReclaimPolicy(): -want, +got\n%s", diff)
 	}
 }
+
+func TestNewManagedGetItems(t *testing.T) {
+	want := `package pkg
+
+import resource "example.org/resource"
+
+// GetItems of this Type.
+func (t *Type) GetItems() []resource.Managed {
+	items := make([]resource.Managed, len(t.Items))
+	for i := range t.Items {
+		items[i] = &t.Items[i]
+	}
+	return items
+}
+`
+	f := jen.NewFile("pkg")
+	NewManagedGetItems("t", "example.org/resource")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewManagedGetItems(): -want, +got\n%s", diff)
+	}
+}
+
+func TestNewClaimGetItems(t *testing.T) {
+	want := `package pkg
+
+import resource "example.org/resource"
+
+// GetItems of this Type.
+func (t *Type) GetItems() []resource.Claim {
+	items := make([]resource.Claim, len(t.Items))
+	for i := range t.Items {
+		items[i] = &t.Items[i]
+	}
+	return items
+}
+`
+	f := jen.NewFile("pkg")
+	NewClaimGetItems("t", "example.org/resource")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewClaimGetItems(): -want, +got\n%s", diff)
+	}
+}
+
+func TestNewClassGetItems(t *testing.T) {
+	want := `package pkg
+
+import resource "example.org/resource"
+
+// GetItems of this Type.
+func (t *Type) GetItems() []resource.Class {
+	items := make([]resource.Class, len(t.Items))
+	for i := range t.Items {
+		items[i] = &t.Items[i]
+	}
+	return items
+}
+`
+	f := jen.NewFile("pkg")
+	NewClassGetItems("t", "example.org/resource")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewClassGetItems(): -want, +got\n%s", diff)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

We strongly recommend you look through our contributor guide at https://git.io/fj2m9
if this is your first time opening a Crossplane pull request. You can find us in
https://slack.crossplane.io/messages/dev if you need any help contributing.
-->

### Description of your changes
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

Fixes #
-->
This allows us to define interfaces that represent a list of managed resources, list of resource claims, etc. For example:

```go
// A ManagedList is a list of managed resources.
type ManagedList interface {
	runtime.Object

	// GetItems returns the list of managed resources.
	GetItems() []Managed
}
```

This enables behaviour such as:

```go
func Policies(ctx context.Context, c client.Client, l resource.ManagedList) []v1alpha1.ReclaimPolicy {
	c.List(ctx, l)
	items := l.GetItems()

	policies := make([]v1alpha1.ReclaimPolicy, len(items)
	for i := range l.GetItems() {
		policies[i] = items[i].GetReclaimPolicy()
	}
	return policies
}
```

### Checklist
<!--
Please run through the below readiness checklist. The first two items are
relevant to every Crossplane pull request.
-->
I have:
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Ensured this PR contains a neat, self documenting set of commits.
