### PR TITLE
Don't generate credentials secret getters and setters

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -148,12 +148,10 @@ func GenerateProviderConfig(filename, header string, p *packages.Package) error 
 	receiver := "p"
 
 	methods := method.Set{
-		"SetCredentialsSecretReference": method.NewSetCredentialsSecretReference(receiver, RuntimeImport),
-		"GetCredentialsSecretReference": method.NewGetCredentialsSecretReference(receiver, RuntimeImport),
-		"SetUsers":                      method.NewSetUsers(receiver),
-		"GetUsers":                      method.NewGetUsers(receiver),
-		"SetConditions":                 method.NewSetConditions(receiver, RuntimeImport),
-		"GetCondition":                  method.NewGetCondition(receiver, RuntimeImport),
+		"SetUsers":      method.NewSetUsers(receiver),
+		"GetUsers":      method.NewGetUsers(receiver),
+		"SetConditions": method.NewSetConditions(receiver, RuntimeImport),
+		"GetCondition":  method.NewGetCondition(receiver, RuntimeImport),
 	}
 
 	err := generate.WriteMethods(p, methods, filepath.Join(filepath.Dir(p.GoFiles[0]), filename),

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -72,9 +72,7 @@ func ProviderConfig() Object {
 		return fields.Has(o,
 			fields.IsTypeMeta().And(fields.IsEmbedded()),
 			fields.IsObjectMeta().And(fields.IsEmbedded()),
-			fields.IsSpec().And(fields.HasFieldThat(
-				fields.IsProviderConfigSpec().And(fields.IsEmbedded()),
-			)),
+			fields.IsSpec(),
 			fields.IsStatus().And(fields.HasFieldThat(
 				fields.IsProviderConfigStatus().And(fields.IsEmbedded()),
 			)),

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -234,30 +234,6 @@ func NewGetDeletionPolicy(receiver, runtime string) New {
 	}
 }
 
-// NewGetCredentialsSecretReference returns a NewMethod that writes a
-// GetCredentialsSecretReference method for the supplied Object to the supplied
-// file.
-func NewGetCredentialsSecretReference(receiver, runtime string) New {
-	return func(f *jen.File, o types.Object) {
-		f.Commentf("GetCredentialsSecretReference of this %s.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetCredentialsSecretReference").Params().Op("*").Qual(runtime, "SecretKeySelector").Block(
-			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("CredentialsSecretRef")),
-		)
-	}
-}
-
-// NewSetCredentialsSecretReference returns a NewMethod that writes a
-// SetCredentialsSecretReference method for the supplied Object to the supplied
-// file.
-func NewSetCredentialsSecretReference(receiver, runtime string) New {
-	return func(f *jen.File, o types.Object) {
-		f.Commentf("SetCredentialsSecretReference of this %s.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetCredentialsSecretReference").Params(jen.Id("r").Op("*").Qual(runtime, "SecretKeySelector")).Block(
-			jen.Id(receiver).Dot(fields.NameSpec).Dot("CredentialsSecretRef").Op("=").Id("r"),
-		)
-	}
-}
-
 // NewSetUsers returns a NewMethod that writes a SetUsers method for the
 // supplied Object to the supplied file.
 func NewSetUsers(receiver string) New {

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -279,40 +279,6 @@ func (t *Type) GetDeletionPolicy() runtime.DeletionPolicy {
 	}
 }
 
-func TestNewSetCredentialsSecretReference(t *testing.T) {
-	want := `package pkg
-
-import runtime "example.org/runtime"
-
-// SetCredentialsSecretReference of this Type.
-func (t *Type) SetCredentialsSecretReference(r *runtime.SecretKeySelector) {
-	t.Spec.CredentialsSecretRef = r
-}
-`
-	f := jen.NewFile("pkg")
-	NewSetCredentialsSecretReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
-	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewSetCredentialsSecretReference(): -want, +got\n%s", diff)
-	}
-}
-
-func TestNewGetCredentialsSecretReference(t *testing.T) {
-	want := `package pkg
-
-import runtime "example.org/runtime"
-
-// GetCredentialsSecretReference of this Type.
-func (t *Type) GetCredentialsSecretReference() *runtime.SecretKeySelector {
-	return t.Spec.CredentialsSecretRef
-}
-`
-	f := jen.NewFile("pkg")
-	NewGetCredentialsSecretReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
-	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetCredentialsSecretLocalReference(): -want, +got\n%s", diff)
-	}
-}
-
 func TestNewSetUsers(t *testing.T) {
 	want := `package pkg
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
In practice we don't use these getters and setters anywhere where we couldn't
just type assert resource.ProviderConfig to the specific type we're dealing
with. See https://github.com/crossplane/crossplane-runtime/pull/212 for more context.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I haven't tested this yet; I'd like to get feedback on https://github.com/crossplane/crossplane-runtime/pull/212 first.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
