### PR TITLE
Remove deprecated ProviderReference methods

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -96,8 +96,6 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 	methods := method.Set{
 		"SetConditions":                       method.NewSetConditions(receiver, RuntimeImport),
 		"GetCondition":                        method.NewGetCondition(receiver, RuntimeImport),
-		"GetProviderReference":                method.NewGetProviderReference(receiver, RuntimeImport),
-		"SetProviderReference":                method.NewSetProviderReference(receiver, RuntimeImport),
 		"GetProviderConfigReference":          method.NewGetProviderConfigReference(receiver, RuntimeImport),
 		"SetProviderConfigReference":          method.NewSetProviderConfigReference(receiver, RuntimeImport),
 		"SetWriteConnectionSecretToReference": method.NewSetWriteConnectionSecretToReference(receiver, RuntimeImport),

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -120,28 +120,6 @@ func NewGetResourceReference(receiver, core string) New {
 	}
 }
 
-// NewSetProviderReference returns a NewMethod that writes a SetProviderReference
-// method for the supplied Object to the supplied file.
-func NewSetProviderReference(receiver, runtime string) New {
-	return func(f *jen.File, o types.Object) {
-		f.Commentf("SetProviderReference of this %s.\nDeprecated: Use SetProviderConfigReference.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetProviderReference").Params(jen.Id("r").Op("*").Qual(runtime, "Reference")).Block(
-			jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderReference").Op("=").Id("r"),
-		)
-	}
-}
-
-// NewGetProviderReference returns a NewMethod that writes a GetProviderReference
-// method for the supplied Object to the supplied file.
-func NewGetProviderReference(receiver, runtime string) New {
-	return func(f *jen.File, o types.Object) {
-		f.Commentf("GetProviderReference of this %s.\nDeprecated: Use GetProviderConfigReference.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetProviderReference").Params().Op("*").Qual(runtime, "Reference").Block(
-			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderReference")),
-		)
-	}
-}
-
 // NewSetProviderConfigReference returns a NewMethod that writes a SetProviderConfigReference
 // method for the supplied Object to the supplied file.
 func NewSetProviderConfigReference(receiver, runtime string) New {

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -137,46 +137,6 @@ func (t *Type) GetProviderConfigReference() *runtime.Reference {
 	}
 }
 
-func TestNewSetProviderReference(t *testing.T) {
-	want := `package pkg
-
-import runtime "example.org/runtime"
-
-/*
-SetProviderReference of this Type.
-Deprecated: Use SetProviderConfigReference.
-*/
-func (t *Type) SetProviderReference(r *runtime.Reference) {
-	t.Spec.ProviderReference = r
-}
-`
-	f := jen.NewFile("pkg")
-	NewSetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
-	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewSetProviderReference(): -want, +got\n%s", diff)
-	}
-}
-
-func TestNewGetProviderReference(t *testing.T) {
-	want := `package pkg
-
-import runtime "example.org/runtime"
-
-/*
-GetProviderReference of this Type.
-Deprecated: Use GetProviderConfigReference.
-*/
-func (t *Type) GetProviderReference() *runtime.Reference {
-	return t.Spec.ProviderReference
-}
-`
-	f := jen.NewFile("pkg")
-	NewGetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
-	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetProviderReference(): -want, +got\n%s", diff)
-	}
-}
-
 func TestNewSetWriteConnectionSecretToReference(t *testing.T) {
 	want := `package pkg
 

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -133,7 +133,7 @@ func (t *Type) GetProviderConfigReference() *runtime.Reference {
 	f := jen.NewFile("pkg")
 	NewGetProviderConfigReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetProviderReference(): -want, +got\n%s", diff)
+		t.Errorf("NewGetProviderConfigReference(): -want, +got\n%s", diff)
 	}
 }
 
@@ -320,7 +320,7 @@ func (t *Type) GetProviderConfigReference() runtime.Reference {
 	f := jen.NewFile("pkg")
 	NewGetRootProviderConfigReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetRootProviderReference(): -want, +got\n%s", diff)
+		t.Errorf("NewGetRootProviderConfigReference(): -want, +got\n%s", diff)
 	}
 }
 
@@ -354,7 +354,7 @@ func (t *Type) GetResourceReference() runtime.TypedReference {
 	f := jen.NewFile("pkg")
 	NewGetRootResourceReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetRootProviderReference(): -want, +got\n%s", diff)
+		t.Errorf("NewGetRootResourceReference(): -want, +got\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Removes the deprecated ProviderReference in favor of only using
ProviderConfigReference.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://github.com/crossplane/crossplane-runtime/pull/241

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Unit tests.

[contribution process]: https://git.io/fj2m9
