### PR TITLE
Revert "Remove deprecated ProviderReference methods"

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -96,6 +96,8 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 	methods := method.Set{
 		"SetConditions":                       method.NewSetConditions(receiver, RuntimeImport),
 		"GetCondition":                        method.NewGetCondition(receiver, RuntimeImport),
+		"GetProviderReference":                method.NewGetProviderReference(receiver, RuntimeImport),
+		"SetProviderReference":                method.NewSetProviderReference(receiver, RuntimeImport),
 		"GetProviderConfigReference":          method.NewGetProviderConfigReference(receiver, RuntimeImport),
 		"SetProviderConfigReference":          method.NewSetProviderConfigReference(receiver, RuntimeImport),
 		"SetWriteConnectionSecretToReference": method.NewSetWriteConnectionSecretToReference(receiver, RuntimeImport),

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -120,6 +120,28 @@ func NewGetResourceReference(receiver, core string) New {
 	}
 }
 
+// NewSetProviderReference returns a NewMethod that writes a SetProviderReference
+// method for the supplied Object to the supplied file.
+func NewSetProviderReference(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("SetProviderReference of this %s.\nDeprecated: Use SetProviderConfigReference.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetProviderReference").Params(jen.Id("r").Op("*").Qual(runtime, "Reference")).Block(
+			jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderReference").Op("=").Id("r"),
+		)
+	}
+}
+
+// NewGetProviderReference returns a NewMethod that writes a GetProviderReference
+// method for the supplied Object to the supplied file.
+func NewGetProviderReference(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetProviderReference of this %s.\nDeprecated: Use GetProviderConfigReference.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetProviderReference").Params().Op("*").Qual(runtime, "Reference").Block(
+			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderReference")),
+		)
+	}
+}
+
 // NewSetProviderConfigReference returns a NewMethod that writes a SetProviderConfigReference
 // method for the supplied Object to the supplied file.
 func NewSetProviderConfigReference(receiver, runtime string) New {

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -137,6 +137,46 @@ func (t *Type) GetProviderConfigReference() *runtime.Reference {
 	}
 }
 
+func TestNewSetProviderReference(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+/*
+SetProviderReference of this Type.
+Deprecated: Use SetProviderConfigReference.
+*/
+func (t *Type) SetProviderReference(r *runtime.Reference) {
+	t.Spec.ProviderReference = r
+}
+`
+	f := jen.NewFile("pkg")
+	NewSetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewSetProviderReference(): -want, +got\n%s", diff)
+	}
+}
+
+func TestNewGetProviderReference(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+/*
+GetProviderReference of this Type.
+Deprecated: Use GetProviderConfigReference.
+*/
+func (t *Type) GetProviderReference() *runtime.Reference {
+	return t.Spec.ProviderReference
+}
+`
+	f := jen.NewFile("pkg")
+	NewGetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewGetProviderReference(): -want, +got\n%s", diff)
+	}
+}
+
 func TestNewSetWriteConnectionSecretToReference(t *testing.T) {
 	want := `package pkg
 


### PR DESCRIPTION
This reverts commit 2ba47acab1a23806a3ffa9cbd1cdf9a3ff80653e.

Signed-off-by: Jan Willies <jan.willies@accenture.com>

### Description of your changes

Generated code is missing `ProviderReference` but until https://github.com/crossplane/crossplane-runtime/pull/241 is merged the `Managed` interface still references it, resulting in errors like this:

```
angryjet: error: error loading packages using pattern ./...: /Users/jan.willies/golang/src/github.com/crossplane-contrib/provider-gitlab/apis/projects/v1alpha1/zz_generated.managedlist.go:36:14: cannot use &l.Items[i] (value of type *Project) as resource.Managed value in assignment: missing method GetProviderReference
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

manual
