### PR TITLE
Use NewFilePath instead of NewFile while creating the File object

### DIFF
--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -83,7 +83,7 @@ func WriteMethods(p *packages.Package, ms method.Set, file string, wo ...WriteOp
 		fn(opts)
 	}
 
-	f := jen.NewFile(p.Name)
+	f := jen.NewFilePath(p.PkgPath)
 	for path, alias := range opts.ImportAliases {
 		f.ImportAlias(path, alias)
 	}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -83,6 +83,13 @@ func WriteMethods(p *packages.Package, ms method.Set, file string, wo ...WriteOp
 		fn(opts)
 	}
 
+	// NewFilePath creates a new File object by taking the full package path such as:
+	// 'github.com/org/repo/apis/resource/v1alpha1'
+	// File object created using the function ('NewFile') that takes only the package
+	// name ('v1alpha1') is not sufficient in order to properly handle imports from
+	// the same package and to communicate with the Jennifer tool correctly.
+	// We need to create the File object by using NewFilePath (passing package path)
+	// so that we can communicate correctly with the library (jennifer).
 	f := jen.NewFilePath(p.PkgPath)
 	for path, alias := range opts.ImportAliases {
 		f.ImportAlias(path, alias)

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -45,7 +45,7 @@ func (t *Type) SetConditions(c ...runtime.Condition) {
 	t.Status.SetConditions(c...)
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetConditions("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetConditions(): -want, +got\n%s", diff)
@@ -62,7 +62,7 @@ func (t *Type) GetCondition(ct runtime.ConditionType) runtime.Condition {
 	return t.Status.GetCondition(ct)
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetCondition("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetCondition(): -want, +got\n%s", diff)
@@ -79,7 +79,7 @@ func (t *Type) SetResourceReference(r *core.ObjectReference) {
 	t.Spec.ResourceReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetResourceReference("t", "example.org/core")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetResourceReference(): -want, +got\n%s", diff)
@@ -96,7 +96,7 @@ func (t *Type) GetResourceReference() *core.ObjectReference {
 	return t.Spec.ResourceReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetResourceReference("t", "example.org/core")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetResourceReference(): -want, +got\n%s", diff)
@@ -113,7 +113,7 @@ func (t *Type) SetProviderConfigReference(r *runtime.Reference) {
 	t.Spec.ProviderConfigReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetProviderConfigReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetProviderConfigReference(): -want, +got\n%s", diff)
@@ -130,7 +130,7 @@ func (t *Type) GetProviderConfigReference() *runtime.Reference {
 	return t.Spec.ProviderConfigReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetProviderConfigReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetProviderConfigReference(): -want, +got\n%s", diff)
@@ -150,7 +150,7 @@ func (t *Type) SetProviderReference(r *runtime.Reference) {
 	t.Spec.ProviderReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetProviderReference(): -want, +got\n%s", diff)
@@ -170,7 +170,7 @@ func (t *Type) GetProviderReference() *runtime.Reference {
 	return t.Spec.ProviderReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetProviderReference(): -want, +got\n%s", diff)
@@ -187,7 +187,7 @@ func (t *Type) SetWriteConnectionSecretToReference(r *runtime.SecretReference) {
 	t.Spec.WriteConnectionSecretToReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetWriteConnectionSecretToReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetWriteConnectionSecretToReference(): -want, +got\n%s", diff)
@@ -204,7 +204,7 @@ func (t *Type) GetWriteConnectionSecretToReference() *runtime.SecretReference {
 	return t.Spec.WriteConnectionSecretToReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetWriteConnectionSecretToReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetWriteConnectionSecretToLocalReference(): -want, +got\n%s", diff)
@@ -221,7 +221,7 @@ func (t *Type) SetWriteConnectionSecretToReference(r *runtime.LocalSecretReferen
 	t.Spec.WriteConnectionSecretToReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewLocalSetWriteConnectionSecretToReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetWriteConnectionSecretToLocalReference(): -want, +got\n%s", diff)
@@ -238,7 +238,7 @@ func (t *Type) GetWriteConnectionSecretToReference() *runtime.LocalSecretReferen
 	return t.Spec.WriteConnectionSecretToReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewLocalGetWriteConnectionSecretToReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetWriteConnectionSecretToReference(): -want, +got\n%s", diff)
@@ -255,7 +255,7 @@ func (t *Type) SetDeletionPolicy(r runtime.DeletionPolicy) {
 	t.Spec.DeletionPolicy = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetDeletionPolicy("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetDeletionPolicy(): -want, +got\n%s", diff)
@@ -272,7 +272,7 @@ func (t *Type) GetDeletionPolicy() runtime.DeletionPolicy {
 	return t.Spec.DeletionPolicy
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetDeletionPolicy("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetDeletionPolicy(): -want, +got\n%s", diff)
@@ -287,7 +287,7 @@ func (t *Type) SetUsers(i int64) {
 	t.Status.Users = i
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetUsers("t")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetUsers(): -want, +got\n%s", diff)
@@ -302,7 +302,7 @@ func (t *Type) GetUsers() int64 {
 	return t.Status.Users
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetUsers("t")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetUsers(): -want, +got\n%s", diff)
@@ -323,7 +323,7 @@ func (t *Type) GetItems() []resource.Managed {
 	return items
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewManagedGetItems("t", "example.org/resource")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewManagedGetItems(): -want, +got\n%s", diff)
@@ -340,7 +340,7 @@ func (t *Type) SetProviderConfigReference(r runtime.Reference) {
 	t.ProviderConfigReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetRootProviderConfigReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetRootProviderConfigReference(): -want, +got\n%s", diff)
@@ -357,7 +357,7 @@ func (t *Type) GetProviderConfigReference() runtime.Reference {
 	return t.ProviderConfigReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetRootProviderConfigReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetRootProviderConfigReference(): -want, +got\n%s", diff)
@@ -374,7 +374,7 @@ func (t *Type) SetResourceReference(r runtime.TypedReference) {
 	t.ResourceReference = r
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewSetRootResourceReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewSetRootResourceReference(): -want, +got\n%s", diff)
@@ -391,7 +391,7 @@ func (t *Type) GetResourceReference() runtime.TypedReference {
 	return t.ResourceReference
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewGetRootResourceReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetRootResourceReference(): -want, +got\n%s", diff)
@@ -412,7 +412,7 @@ func (t *Type) GetItems() []resource.ProviderConfigUsage {
 	return items
 }
 `
-	f := jen.NewFile("pkg")
+	f := jen.NewFilePath("pkg")
 	NewProviderConfigUsageGetItems("t", "example.org/resource")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewProviderConfigUsageGetItems(): -want, +got\n%s", diff)

--- a/internal/method/resolver_test.go
+++ b/internal/method/resolver_test.go
@@ -57,6 +57,10 @@ type ModelParameters struct {
 	// +crossplane:generate:reference:type=RouteTable
 	RouteTableIDs []*string
 
+	// +crossplane:generate:reference:type=golang.org/fake/v1alpha1.Configuration
+	// +crossplane:generate:reference:extractor=golang.org/fake/v1alpha1.Configurations()
+	Configurations *Configuration
+
 	UnrelatedField string
 }
 
@@ -69,6 +73,8 @@ type OtherSpec struct {
 	// +crossplane:generate:reference:type=Cluster
 	OtherID string
 }
+
+type Configuration struct {}
 
 type ModelSpec struct {
 	ForProvider       ModelParameters
@@ -220,6 +226,22 @@ func (mg *Model) ResolveReferences(ctx context.Context, c client.Reader) error {
 	mg.Spec.ForProvider.RouteTableIDs = reference.ToPtrValues(mrsp.ResolvedValues)
 	mg.Spec.ForProvider.RouteTableIDsRefs = mrsp.ResolvedReferences
 
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Configurations),
+		Extract:      Configurations(),
+		Reference:    mg.Spec.ForProvider.ConfigurationsRef,
+		Selector:     mg.Spec.ForProvider.ConfigurationsSelector,
+		To: reference.To{
+			List:    &ConfigurationList{},
+			Managed: &Configuration{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.Configurations")
+	}
+	mg.Spec.ForProvider.Configurations = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.ConfigurationsRef = rsp.ResolvedReference
+
 	return nil
 }
 `
@@ -238,7 +260,7 @@ func TestNewResolveReferences(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	f := jen.NewFile("v1alpha1")
+	f := jen.NewFilePath("golang.org/fake/v1alpha1")
 	NewResolveReferences(xptypes.NewTraverser(comments.In(pkgs[0])), "mg", "example.org/client", "example.org/reference")(f, pkgs[0].Types.Scope().Lookup("Model"))
 	if diff := cmp.Diff(generated, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewResolveReferences(): -want, +got\n%s", diff)

--- a/internal/method/resolver_test.go
+++ b/internal/method/resolver_test.go
@@ -57,11 +57,11 @@ type ModelParameters struct {
 	// +crossplane:generate:reference:type=RouteTable
 	RouteTableIDs []*string
 
-	// +crossplane:generate:reference:type=golang.org/fake/v1alpha1.Configuration
-	// +crossplane:generate:reference:extractor=golang.org/fake/v1alpha1.Configurations()
-	Configurations *Configuration
-
 	UnrelatedField string
+
+	// +crossplane:generate:reference:type=golang.org/fake/v1alpha1.Configuration
+	// +crossplane:generate:reference:extractor=golang.org/fake/v1alpha1.Configuration()
+	CustomConfiguration *Configuration
 }
 
 type NetworkSpec struct {
@@ -73,8 +73,6 @@ type OtherSpec struct {
 	// +crossplane:generate:reference:type=Cluster
 	OtherID string
 }
-
-type Configuration struct {}
 
 type ModelSpec struct {
 	ForProvider       ModelParameters
@@ -227,20 +225,20 @@ func (mg *Model) ResolveReferences(ctx context.Context, c client.Reader) error {
 	mg.Spec.ForProvider.RouteTableIDsRefs = mrsp.ResolvedReferences
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.Configurations),
-		Extract:      Configurations(),
-		Reference:    mg.Spec.ForProvider.ConfigurationsRef,
-		Selector:     mg.Spec.ForProvider.ConfigurationsSelector,
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.CustomConfiguration),
+		Extract:      Configuration(),
+		Reference:    mg.Spec.ForProvider.CustomConfigurationRef,
+		Selector:     mg.Spec.ForProvider.CustomConfigurationSelector,
 		To: reference.To{
 			List:    &ConfigurationList{},
 			Managed: &Configuration{},
 		},
 	})
 	if err != nil {
-		return errors.Wrap(err, "mg.Spec.ForProvider.Configurations")
+		return errors.Wrap(err, "mg.Spec.ForProvider.CustomConfiguration")
 	}
-	mg.Spec.ForProvider.Configurations = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.ConfigurationsRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.CustomConfiguration = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.CustomConfigurationRef = rsp.ResolvedReference
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Sergen Yalçın <yalcinsergen97@gmail.com>

### Description of your changes

Fixes https://github.com/crossplane/terrajet/issues/228

While writing the files, the `NewFile` function was used for creating the `File` object. This function takes only the `packageName` as parameter. When we create the `File` object this function, since the tool does not have the entire file path, it cannot detect whether the import is from the same package.

In this PR, `NewFilePath` function is used instead of `NewFile` while creating the `File` object. `NewFilePath` function takes the `packagePath` as parameter. By this way, while determining the imports, the tool can detect whether the import path is from the same package.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

The two test cases were applied for this PR:
- Generate the provider-jet-aws resources again to check there is not any difference.
- `aws_iam_access_key` resource has `aws_iam_user` reference:

```
r.References = config.References{
	"user": config.Reference{
		Type: "User",
	},
}
```

This block was changed with the following one:

```
r.References = config.References{
	"user": config.Reference{
		Type: "github.com/crossplane-contrib/provider-jet-aws/apis/iam/v1alpha2.User",
	},
}
```

In new configuration the full path of the reference package was used, then the resources were generated. This case is also successful.

[contribution process]: https://git.io/fj2m9
