### PR TITLE
Generate methods for PublishConnectionDetailsTo API

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -112,6 +112,8 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 		"SetProviderConfigReference":          method.NewSetProviderConfigReference(receiver, RuntimeImport),
 		"SetWriteConnectionSecretToReference": method.NewSetWriteConnectionSecretToReference(receiver, RuntimeImport),
 		"GetWriteConnectionSecretToReference": method.NewGetWriteConnectionSecretToReference(receiver, RuntimeImport),
+		"SetPublishConnectionDetailsTo":       method.NewSetPublishConnectionDetailsTo(receiver, RuntimeImport),
+		"GetPublishConnectionDetailsTo":       method.NewGetPublishConnectionDetailsTo(receiver, RuntimeImport),
 		"SetDeletionPolicy":                   method.NewSetDeletionPolicy(receiver, RuntimeImport),
 		"GetDeletionPolicy":                   method.NewGetDeletionPolicy(receiver, RuntimeImport),
 	}

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -188,6 +188,30 @@ func NewGetWriteConnectionSecretToReference(receiver, runtime string) New {
 	}
 }
 
+// NewSetPublishConnectionDetailsTo returns a NewMethod that writes a
+// NewSetPublishConnectionDetailsTo method for the supplied Object to the
+// supplied file.
+func NewSetPublishConnectionDetailsTo(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("SetPublishConnectionDetailsTo of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetPublishConnectionDetailsTo").Params(jen.Id("r").Op("*").Qual(runtime, "PublishConnectionDetailsTo")).Block(
+			jen.Id(receiver).Dot(fields.NameSpec).Dot("PublishConnectionDetailsTo").Op("=").Id("r"),
+		)
+	}
+}
+
+// NewGetPublishConnectionDetailsTo returns a NewMethod that writes a
+// GetPublishConnectionDetailsTo method for the supplied Object to the
+// supplied file.
+func NewGetPublishConnectionDetailsTo(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetPublishConnectionDetailsTo of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetPublishConnectionDetailsTo").Params().Op("*").Qual(runtime, "PublishConnectionDetailsTo").Block(
+			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("PublishConnectionDetailsTo")),
+		)
+	}
+}
+
 // NewLocalSetWriteConnectionSecretToReference returns a NewMethod that writes a
 // SetWriteConnectionSecretToReference method for the supplied Object to the
 // supplied file.

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -194,6 +194,23 @@ func (t *Type) SetWriteConnectionSecretToReference(r *runtime.SecretReference) {
 	}
 }
 
+func TestNewSetPublishConnectionDetailsTo(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+// SetPublishConnectionDetailsTo of this Type.
+func (t *Type) SetPublishConnectionDetailsTo(r *runtime.PublishConnectionDetailsTo) {
+	t.Spec.PublishConnectionDetailsTo = r
+}
+`
+	f := jen.NewFile("pkg")
+	NewSetPublishConnectionDetailsTo("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewSetPublishConnectionDetailsTo(): -want, +got\n%s", diff)
+	}
+}
+
 func TestNewGetWriteConnectionSecretToReference(t *testing.T) {
 	want := `package pkg
 
@@ -208,6 +225,23 @@ func (t *Type) GetWriteConnectionSecretToReference() *runtime.SecretReference {
 	NewGetWriteConnectionSecretToReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewGetWriteConnectionSecretToLocalReference(): -want, +got\n%s", diff)
+	}
+}
+
+func TestNewGetPublishConnectionDetailsTo(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+// GetPublishConnectionDetailsTo of this Type.
+func (t *Type) GetPublishConnectionDetailsTo() *runtime.PublishConnectionDetailsTo {
+	return t.Spec.PublishConnectionDetailsTo
+}
+`
+	f := jen.NewFile("pkg")
+	NewGetPublishConnectionDetailsTo("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewGetPublishConnectionDetailsTo(): -want, +got\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

This PR adds support for generating the following methods on `Managed` resources as part of [External Secret Stores support work](https://github.com/crossplane/crossplane/issues/2366):

- `GetPublishConnectionDetailsTo() *xpv1.PublishConnectionDetailsTo`
- `SetPublishConnectionDetailsTo(r *xpv1.PublishConnectionDetailsTo)`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

From **_provider-gcp_**:

1. Replace _crossplane-tools_ with this PR.
2. Replace _crossplane-runtime_ with [this](https://github.com/crossplane/crossplane-runtime/pull/323) Crossplane runtime PR.
3. Temporarily comment out [ConnectionDetailsPublisherTo](https://github.com/crossplane/crossplane-runtime/pull/323/files#diff-bb556e69137384d0ed92c340153015de882833117bd14d6154aabae4c7c282afR172) from managed interface.
4. Run `make generate`.
5. Revert comment added in step 3.
6. Run `make generate`.
7. Verify new methods generated and code builds & runs.

[contribution process]: https://git.io/fj2m9
