### PR TITLE
Generate Getters/Setters for Management Policy

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -114,6 +114,8 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 		"GetWriteConnectionSecretToReference": method.NewGetWriteConnectionSecretToReference(receiver, RuntimeImport),
 		"SetPublishConnectionDetailsTo":       method.NewSetPublishConnectionDetailsTo(receiver, RuntimeImport),
 		"GetPublishConnectionDetailsTo":       method.NewGetPublishConnectionDetailsTo(receiver, RuntimeImport),
+		"SetManagementPolicy":                 method.NewSetManagementPolicy(receiver, RuntimeImport),
+		"GetManagementPolicy":                 method.NewGetManagementPolicy(receiver, RuntimeImport),
 		"SetDeletionPolicy":                   method.NewSetDeletionPolicy(receiver, RuntimeImport),
 		"GetDeletionPolicy":                   method.NewGetDeletionPolicy(receiver, RuntimeImport),
 	}

--- a/cmd/breakingChanges/main_test.go
+++ b/cmd/breakingChanges/main_test.go
@@ -55,7 +55,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy": {},
+								"managementPolicy": {},
+								"deletionPolicy":   {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"description":             {},
@@ -124,7 +125,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy": {},
+								"managementPolicy": {},
+								"deletionPolicy":   {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"description":             {},
@@ -184,7 +186,8 @@ func TestBreakingChanges(t *testing.T) {
 					Properties: map[string]v1.JSONSchemaProps{
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy": {},
+								"deletionPolicy":   {},
+								"managementPolicy": {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"description":             {},
@@ -206,7 +209,8 @@ func TestBreakingChanges(t *testing.T) {
 					Properties: map[string]v1.JSONSchemaProps{
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy": {},
+								"deletionPolicy":   {},
+								"managementPolicy": {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"enableInboundForwarding": {},
@@ -248,7 +252,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy": {},
+								"managementPolicy": {},
+								"deletionPolicy":   {},
 							},
 						},
 					},
@@ -269,7 +274,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy": {},
+								"managementPolicy": {},
+								"deletionPolicy":   {},
 							},
 						},
 					},

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -236,6 +236,28 @@ func NewLocalGetWriteConnectionSecretToReference(receiver, runtime string) New {
 	}
 }
 
+// NewSetManagementPolicy returns a NewMethod that writes a SetManagementPolicy
+// method for the supplied Object to the supplied file.
+func NewSetManagementPolicy(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("SetManagementPolicy of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetManagementPolicy").Params(jen.Id("r").Qual(runtime, "ManagementPolicy")).Block(
+			jen.Id(receiver).Dot(fields.NameSpec).Dot("ManagementPolicy").Op("=").Id("r"),
+		)
+	}
+}
+
+// NewGetManagementPolicy returns a NewMethod that writes a GetManagementPolicy
+// method for the supplied Object to the supplied file.
+func NewGetManagementPolicy(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetManagementPolicy of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetManagementPolicy").Params().Qual(runtime, "ManagementPolicy").Block(
+			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ManagementPolicy")),
+		)
+	}
+}
+
 // NewSetDeletionPolicy returns a NewMethod that writes a SetDeletionPolicy
 // method for the supplied Object to the supplied file.
 func NewSetDeletionPolicy(receiver, runtime string) New {

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -279,6 +279,40 @@ func (t *Type) GetWriteConnectionSecretToReference() *runtime.LocalSecretReferen
 	}
 }
 
+func TestNewSetManagementPolicy(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+// SetManagementPolicy of this Type.
+func (t *Type) SetManagementPolicy(r runtime.ManagementPolicy) {
+	t.Spec.ManagementPolicy = r
+}
+`
+	f := jen.NewFilePath("pkg")
+	NewSetManagementPolicy("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewSetManagementPolicy(): -want, +got\n%s", diff)
+	}
+}
+
+func TestNewGetManagementPolicy(t *testing.T) {
+	want := `package pkg
+
+import runtime "example.org/runtime"
+
+// GetManagementPolicy of this Type.
+func (t *Type) GetManagementPolicy() runtime.ManagementPolicy {
+	return t.Spec.ManagementPolicy
+}
+`
+	f := jen.NewFilePath("pkg")
+	NewGetManagementPolicy("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
+		t.Errorf("NewGetManagementPolicy(): -want, +got\n%s", diff)
+	}
+}
+
 func TestNewSetDeletionPolicy(t *testing.T) {
 	want := `package pkg
 


### PR DESCRIPTION
### Description of your changes

This PR generates getters/setters for `spec.managementPolicy` that is proposed in the [Observe Only design proposal](https://github.com/crossplane/crossplane/pull/3531).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I consumed this PR by updating go.mod of a provider and run `make generate`.

[contribution process]: https://git.io/fj2m9
