### PR TITLE
Update link to Provider Development Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Code generators for [Crossplane] controllers.
 crossplane-runtime's interfaces (such as [`resource.Managed`]) and automatically
 generate the method set required to satisfy that interface. A struct is
 considered capable of satisfying crossplane-runtime's interfaces based on the
-heuristics described in the [Crossplane Services Developer Guide], for example a
+heuristics described in the [Provider Development Guide], for example a
 managed resource must:
 
 * Embed a [`ResourceStatus`] struct in their `Status` struct.
@@ -94,4 +94,4 @@ Args:
 [`resource.Managed`]: https://godoc.org/github.com/crossplane/crossplane-runtime/pkg/resource#Managed
 [`ResourceSpec`]: https://godoc.org/github.com/crossplane/crossplane-runtime/apis/common/v1#ResourceSpec
 [`ResourceStatus`]: https://godoc.org/github.com/crossplane/crossplane-runtime/apis/common/v1#ResourceStatus
-[Crossplane Services Developer Guide]: https://crossplane.io/docs/v0.3/services-developer-guide.html#defining-resource-kinds
+[Provider Development Guide]: https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md#defining-resource-kinds


### PR DESCRIPTION
### Description of your changes

This PR updates an ancient link to the provider development guide in its new home in the contributing folder in the core crossplane repo.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I have tested/inspected the new readme update in my fork: https://github.com/jbw976/crossplane-tools/blob/ancient-dev-guide/README.md

[contribution process]: https://git.io/fj2m9
