### PR TITLE
Changed ManagementPolicy to ManagementPolicies

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -114,8 +114,8 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 		"GetWriteConnectionSecretToReference": method.NewGetWriteConnectionSecretToReference(receiver, RuntimeImport),
 		"SetPublishConnectionDetailsTo":       method.NewSetPublishConnectionDetailsTo(receiver, RuntimeImport),
 		"GetPublishConnectionDetailsTo":       method.NewGetPublishConnectionDetailsTo(receiver, RuntimeImport),
-		"SetManagementPolicy":                 method.NewSetManagementPolicy(receiver, RuntimeImport),
-		"GetManagementPolicy":                 method.NewGetManagementPolicy(receiver, RuntimeImport),
+		"SetManagementPolicies":               method.NewSetManagementPolicies(receiver, RuntimeImport),
+		"GetManagementPolicies":               method.NewGetManagementPolicies(receiver, RuntimeImport),
 		"SetDeletionPolicy":                   method.NewSetDeletionPolicy(receiver, RuntimeImport),
 		"GetDeletionPolicy":                   method.NewGetDeletionPolicy(receiver, RuntimeImport),
 	}

--- a/cmd/breakingChanges/main_test.go
+++ b/cmd/breakingChanges/main_test.go
@@ -55,8 +55,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"managementPolicy": {},
-								"deletionPolicy":   {},
+								"managementPolicies": {},
+								"deletionPolicy":     {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"description":             {},
@@ -125,8 +125,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"managementPolicy": {},
-								"deletionPolicy":   {},
+								"managementPolicies": {},
+								"deletionPolicy":     {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"description":             {},
@@ -186,8 +186,8 @@ func TestBreakingChanges(t *testing.T) {
 					Properties: map[string]v1.JSONSchemaProps{
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy":   {},
-								"managementPolicy": {},
+								"deletionPolicy":     {},
+								"managementPolicies": {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"description":             {},
@@ -209,8 +209,8 @@ func TestBreakingChanges(t *testing.T) {
 					Properties: map[string]v1.JSONSchemaProps{
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"deletionPolicy":   {},
-								"managementPolicy": {},
+								"deletionPolicy":     {},
+								"managementPolicies": {},
 								"forProvider": {
 									Properties: map[string]v1.JSONSchemaProps{
 										"enableInboundForwarding": {},
@@ -252,8 +252,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"managementPolicy": {},
-								"deletionPolicy":   {},
+								"managementPolicies": {},
+								"deletionPolicy":     {},
 							},
 						},
 					},
@@ -274,8 +274,8 @@ func TestBreakingChanges(t *testing.T) {
 						},
 						"spec": {
 							Properties: map[string]v1.JSONSchemaProps{
-								"managementPolicy": {},
-								"deletionPolicy":   {},
+								"managementPolicies": {},
+								"deletionPolicy":     {},
 							},
 						},
 					},

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -236,24 +236,24 @@ func NewLocalGetWriteConnectionSecretToReference(receiver, runtime string) New {
 	}
 }
 
-// NewSetManagementPolicy returns a NewMethod that writes a SetManagementPolicy
+// NewSetManagementPolicies returns a NewMethod that writes a SetManagementPolicies
 // method for the supplied Object to the supplied file.
-func NewSetManagementPolicy(receiver, runtime string) New {
+func NewSetManagementPolicies(receiver, runtime string) New {
 	return func(f *jen.File, o types.Object) {
-		f.Commentf("SetManagementPolicy of this %s.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetManagementPolicy").Params(jen.Id("r").Qual(runtime, "ManagementPolicy")).Block(
-			jen.Id(receiver).Dot(fields.NameSpec).Dot("ManagementPolicy").Op("=").Id("r"),
+		f.Commentf("SetManagementPolicies of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetManagementPolicies").Params(jen.Id("r").Qual(runtime, "ManagementPolicies")).Block(
+			jen.Id(receiver).Dot(fields.NameSpec).Dot("ManagementPolicies").Op("=").Id("r"),
 		)
 	}
 }
 
-// NewGetManagementPolicy returns a NewMethod that writes a GetManagementPolicy
+// NewGetManagementPolicies returns a NewMethod that writes a GetManagementPolicies
 // method for the supplied Object to the supplied file.
-func NewGetManagementPolicy(receiver, runtime string) New {
+func NewGetManagementPolicies(receiver, runtime string) New {
 	return func(f *jen.File, o types.Object) {
-		f.Commentf("GetManagementPolicy of this %s.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetManagementPolicy").Params().Qual(runtime, "ManagementPolicy").Block(
-			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ManagementPolicy")),
+		f.Commentf("GetManagementPolicies of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetManagementPolicies").Params().Qual(runtime, "ManagementPolicies").Block(
+			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ManagementPolicies")),
 		)
 	}
 }

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -279,37 +279,37 @@ func (t *Type) GetWriteConnectionSecretToReference() *runtime.LocalSecretReferen
 	}
 }
 
-func TestNewSetManagementPolicy(t *testing.T) {
+func TestNewSetManagementPolicies(t *testing.T) {
 	want := `package pkg
 
 import runtime "example.org/runtime"
 
-// SetManagementPolicy of this Type.
-func (t *Type) SetManagementPolicy(r runtime.ManagementPolicy) {
-	t.Spec.ManagementPolicy = r
+// SetManagementPolicies of this Type.
+func (t *Type) SetManagementPolicies(r runtime.ManagementPolicies) {
+	t.Spec.ManagementPolicies = r
 }
 `
 	f := jen.NewFilePath("pkg")
-	NewSetManagementPolicy("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	NewSetManagementPolicies("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewSetManagementPolicy(): -want, +got\n%s", diff)
+		t.Errorf("NewSetManagementPolicies(): -want, +got\n%s", diff)
 	}
 }
 
-func TestNewGetManagementPolicy(t *testing.T) {
+func TestNewGetManagementPolicies(t *testing.T) {
 	want := `package pkg
 
 import runtime "example.org/runtime"
 
-// GetManagementPolicy of this Type.
-func (t *Type) GetManagementPolicy() runtime.ManagementPolicy {
-	return t.Spec.ManagementPolicy
+// GetManagementPolicies of this Type.
+func (t *Type) GetManagementPolicies() runtime.ManagementPolicies {
+	return t.Spec.ManagementPolicies
 }
 `
 	f := jen.NewFilePath("pkg")
-	NewGetManagementPolicy("t", "example.org/runtime")(f, MockObject{Named: "Type"})
+	NewGetManagementPolicies("t", "example.org/runtime")(f, MockObject{Named: "Type"})
 	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetManagementPolicy(): -want, +got\n%s", diff)
+		t.Errorf("NewGetManagementPolicies(): -want, +got\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Changes the generated ManagementPolicy Getters/Setters introduced https://github.com/crossplane/crossplane-tools/pull/51 to ManagementPolicies Getters/Setters, due to changing of the `spec.managementPolicy` field to `spec.managementPolicies`. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].

### How has this code been tested

Updated a `go.mod` of an provider ran `make generate`.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
