### PR TITLE
Remove providerRef generation

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -106,8 +106,6 @@ func GenerateManaged(filename, header string, p *packages.Package) error {
 	methods := method.Set{
 		"SetConditions":                       method.NewSetConditions(receiver, RuntimeImport),
 		"GetCondition":                        method.NewGetCondition(receiver, RuntimeImport),
-		"GetProviderReference":                method.NewGetProviderReference(receiver, RuntimeImport),
-		"SetProviderReference":                method.NewSetProviderReference(receiver, RuntimeImport),
 		"GetProviderConfigReference":          method.NewGetProviderConfigReference(receiver, RuntimeImport),
 		"SetProviderConfigReference":          method.NewSetProviderConfigReference(receiver, RuntimeImport),
 		"SetWriteConnectionSecretToReference": method.NewSetWriteConnectionSecretToReference(receiver, RuntimeImport),

--- a/cmd/breakingChanges/old.yaml
+++ b/cmd/breakingChanges/old.yaml
@@ -149,17 +149,6 @@ spec:
                 required:
                 - name
                 type: object
-              providerRef:
-                description: 'ProviderReference specifies the provider that will be
-                  used to create, observe, update, and delete this managed resource.
-                  Deprecated: Please use ProviderConfigReference, i.e. `providerConfigRef`'
-                properties:
-                  name:
-                    description: Name of the referenced object.
-                    type: string
-                required:
-                - name
-                type: object
               publishConnectionDetailsTo:
                 description: PublishConnectionDetailsTo specifies the connection secret
                   config which contains a name, metadata and a reference to secret

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -120,28 +120,6 @@ func NewGetResourceReference(receiver, core string) New {
 	}
 }
 
-// NewSetProviderReference returns a NewMethod that writes a SetProviderReference
-// method for the supplied Object to the supplied file.
-func NewSetProviderReference(receiver, runtime string) New {
-	return func(f *jen.File, o types.Object) {
-		f.Commentf("SetProviderReference of this %s.\nDeprecated: Use SetProviderConfigReference.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetProviderReference").Params(jen.Id("r").Op("*").Qual(runtime, "Reference")).Block(
-			jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderReference").Op("=").Id("r"),
-		)
-	}
-}
-
-// NewGetProviderReference returns a NewMethod that writes a GetProviderReference
-// method for the supplied Object to the supplied file.
-func NewGetProviderReference(receiver, runtime string) New {
-	return func(f *jen.File, o types.Object) {
-		f.Commentf("GetProviderReference of this %s.\nDeprecated: Use GetProviderConfigReference.", o.Name())
-		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetProviderReference").Params().Op("*").Qual(runtime, "Reference").Block(
-			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderReference")),
-		)
-	}
-}
-
 // NewSetProviderConfigReference returns a NewMethod that writes a SetProviderConfigReference
 // method for the supplied Object to the supplied file.
 func NewSetProviderConfigReference(receiver, runtime string) New {

--- a/internal/method/method_test.go
+++ b/internal/method/method_test.go
@@ -137,46 +137,6 @@ func (t *Type) GetProviderConfigReference() *runtime.Reference {
 	}
 }
 
-func TestNewSetProviderReference(t *testing.T) {
-	want := `package pkg
-
-import runtime "example.org/runtime"
-
-/*
-SetProviderReference of this Type.
-Deprecated: Use SetProviderConfigReference.
-*/
-func (t *Type) SetProviderReference(r *runtime.Reference) {
-	t.Spec.ProviderReference = r
-}
-`
-	f := jen.NewFilePath("pkg")
-	NewSetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
-	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewSetProviderReference(): -want, +got\n%s", diff)
-	}
-}
-
-func TestNewGetProviderReference(t *testing.T) {
-	want := `package pkg
-
-import runtime "example.org/runtime"
-
-/*
-GetProviderReference of this Type.
-Deprecated: Use GetProviderConfigReference.
-*/
-func (t *Type) GetProviderReference() *runtime.Reference {
-	return t.Spec.ProviderReference
-}
-`
-	f := jen.NewFilePath("pkg")
-	NewGetProviderReference("t", "example.org/runtime")(f, MockObject{Named: "Type"})
-	if diff := cmp.Diff(want, fmt.Sprintf("%#v", f)); diff != "" {
-		t.Errorf("NewGetProviderReference(): -want, +got\n%s", diff)
-	}
-}
-
 func TestNewSetWriteConnectionSecretToReference(t *testing.T) {
 	want := `package pkg
 


### PR DESCRIPTION
### Description of your changes

After this PR, we should not generate `providerRef`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Unit tests.
