### PR TITLE
Fix Go version handling, hopefully

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,9 @@ jobs:
         run: make modules.download modules.check
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_VERSION }}
-          skip-go-installation: true
 
   check-diff:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   # Common versions
-  GOLANGCI_VERSION: 'v1.47.3'
+  GOLANGCI_VERSION: 'v1.62.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.18'
   GOLANGCI_VERSION: 'v1.47.3'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
@@ -47,9 +46,9 @@ jobs:
           submodules: true
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Go Build Cache
         id: go
@@ -72,10 +71,6 @@ jobs:
       - name: Download Go Modules
         run: make modules.download modules.check
 
-      # This action uses its own setup-go, which always seems to use the latest
-      # stable version of Go. We could run 'make lint' to ensure our desired Go
-      # version, but we prefer this action because it leaves 'annotations' (i.e.
-      # it comments on PRs to point out linter violations).
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -94,9 +89,9 @@ jobs:
           submodules: true
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Go Build Cache
         id: go
@@ -137,9 +132,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Go Build Cache
         id: go
@@ -197,9 +192,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Go Build Cache
         id: go
@@ -259,9 +254,9 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Find the Go Build Cache
         id: go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -146,11 +146,6 @@ linters-settings:
     tab-width: 1
 
   unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    exported-is-used: true
     exported-fields-are-used: true
 
   unparam:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,104 @@ run:
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  formats: colored-line-number
+  formats:
+    - format: colored-line-number
+      path: stderr
+
+linters:
+  enable-all: true
+  fast: false
+  
+  disable:
+    # These linters are all deprecated. We disable them explicitly to avoid the
+    # linter logging deprecation warnings.
+    - execinquery
+
+    # These are linters we'd like to enable, but that will be labor intensive to
+    # make existing code compliant.
+    - wrapcheck
+    - varnamelen
+    - testpackage
+    - paralleltest
+    - nilnil
+    - gomnd
+
+    # Below are linters that lint for things we don't value. Each entry below
+    # this line must have a comment explaining the rationale.
+
+    # These linters add whitespace in an attempt to make code more readable.
+    # This isn't a widely accepted Go best practice, and would be laborious to
+    # apply to existing code.
+    - wsl 
+    - nlreturn
+
+    # Warns about uses of fmt.Sprintf that are less performant than alternatives
+    # such as string concatenation. We value readability more than performance
+    # unless performance is measured to be an issue.
+    - perfsprint
+
+    # This linter:
+    #
+    # 1. Requires errors.Is/errors.As to test equality.
+    # 2. Requires all errors be wrapped with fmt.Errorf specifically.
+    # 3. Disallows errors.New inline - requires package level errors.
+    #
+    # 1 is covered by other linters. 2 is covered by wrapcheck, which can also
+    # handle our use of crossplane-runtime's errors package. 3 is more strict
+    # than we need. Not every error needs to be tested for equality.
+    - err113
+
+    # These linters duplicate gocognit, but calculate complexity differently.
+    - gocyclo
+    - cyclop
+    - nestif
+    - funlen
+    - maintidx
+
+    # Enforces max line length. It's not idiomatic to enforce a strict limit on
+    # line length in Go. We'd prefer to lint for things that often cause long
+    # lines, like functions with too many parameters or long parameter names
+    # that duplicate their types.
+    - lll
+
+    # Warns about struct instantiations that don't specify every field. Could be
+    # useful in theory to catch fields that are accidentally omitted. Seems like
+    # it would have many more false positives than useful catches, though.
+    - exhaustruct
+
+    # Warns about TODO comments. The rationale being they should be issues
+    # instead. We're okay with using TODO to track minor cleanups for next time
+    # we touch a particular file.
+    - godox
+
+    # Warns about duplicated code blocks within the same file. Could be useful
+    # to prompt folks to think about whether code should be broken out into a
+    # function, but generally we're less worried about DRY and fine with a
+    # little copying. We don't want to give folks the impression that we require
+    # every duplicated code block to be factored out into a function.
+    - dupl
+
+    # Warns about returning interfaces rather than concrete types. We do think
+    # it's best to avoid returning interfaces where possible. However, at the
+    # time of writing enabling this linter would only catch the (many) cases
+    # where we must return an interface. 
+    - ireturn
+
+    # Warns about returning named variables. We do think it's best to avoid
+    # returning named variables where possible. However, at the time of writing
+    # enabling this linter would only catch the (many) cases where returning
+    # named variables is useful to document what the variables are. For example
+    # we believe it makes sense to return (ready bool) rather than just (bool)
+    # to communicate what the bool means.
+    - nonamedreturns
+
+    # Warns about taking the address of a range variable. This isn't an issue in
+    # Go v1.22 and above: https://tip.golang.org/doc/go1.22
+    - exportloopref
+
+    # Warns about using magic numbers. We do think it's best to avoid magic
+    # numbers, but we should not be strict about it.
+    - mnd
 
 linters-settings:
   errcheck:
@@ -15,35 +112,24 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
 
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    exclude-functions: fmt:.*,io/ioutil:^Read.*
-
   govet:
     # report about shadowed variables
-    check-shadowing: false
-
-  revive:
-    # confidence for issues, default is 0.8
-    confidence: 0.8
+    disable:
+      - shadow
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
 
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/crossplane
-
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 10
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
+  gci:
+    custom-order: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/crossplane/crossplane-runtime)
+      - prefix(github.com/crossplane/crossplane)
+      - blank
+      - dot
 
   dupl:
     # tokens count to trigger issue, 150 by default
@@ -64,7 +150,8 @@ linters-settings:
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
     # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
     # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
+    exported-is-used: true
+    exported-fields-are-used: true
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -99,47 +186,64 @@ linters-settings:
       rangeValCopy:
         sizeThreshold: 32
 
-linters:
-  enable:
-    - gosimple
-    - staticcheck
-    - unused
-    - govet
-    - gocyclo
-    - gocritic
-    - goconst
-    - goimports
-    - gofmt  # We enable this as well as goimports for its simplify mode.
-    - prealloc
-    - revive
-    - unconvert
-    - misspell
-    - nakedret
+  nolintlint:
+    require-explanation: true
+    require-specific: true
+  
+  depguard:
+    rules:
+      no_third_party_test_libraries:
+        list-mode: lax
+        files:
+        - $test
+        deny:
+        - pkg: github.com/stretchr/testify
+          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
+        - pkg: github.com/onsi/ginkgo
+          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
+        - pkg: github.com/onsi/gomega
+          desc: "See https://go.dev/wiki/TestComments#assert-libraries"
 
-  presets:
-    - bugs
-    - unused
-  fast: false
-
+  interfacebloat:
+    max: 5
+  
+  tagliatelle:
+    case:
+      rules:
+        json: goCamel
 
 issues:
-  # Excluding configuration per-path and per-linter
+  # Excluding generated files.
+  exclude-files:
+  - "zz_generated\\..+\\.go$"
+  - ".+\\.pb.go$"
+  # Excluding configuration per-path and per-linter.
   exclude-rules:
     # Exclude some linters from running on tests files.
     - path: _test(ing)?\.go
       linters:
-        - gocyclo
+        - gocognit
         - errcheck
-        - dupl
         - gosec
         - scopelint
         - unparam
+        - gochecknoinits
+        - gochecknoglobals
+        - containedctx
+        - forcetypeassert
 
     # Ease some gocritic warnings on test files.
     - path: _test\.go
       text: "(unnamedResult|exitAfterDefer)"
       linters:
         - gocritic
+    
+    # It's idiomatic to register Kubernetes types with a package scoped
+    # SchemeBuilder using an init function.
+    - path: apis/
+      linters:
+      - gochecknoinits
+      - gochecknoglobals
 
     # These are performance optimisations rather than style issues per se.
     # They warn when function arguments or range values copy a lot of memory
@@ -172,6 +276,25 @@ issues:
       - gosec
       - gas
 
+    # This is about implicit memory aliasing in a range loop.
+    # This is a false positive with Go v1.22 and above.
+    - text: "G601:"
+      linters:
+      - gosec
+      - gas
+    
+    # Some k8s dependencies do not have JSON tags on all fields in structs.
+    - path: k8s.io/
+      linters:
+      - musttag
+
+    # Various fields related to native patch and transform Composition are
+    # deprecated, but we can't drop support from Crossplane 1.x. We ignore the
+    # warnings globally instead of suppressing them with comments everywhere.
+    - text: "SA1019: .+ is deprecated: Use Composition Functions instead."
+      linters:
+      - staticcheck
+
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.
@@ -187,7 +310,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/angryjet
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
-GO_SUBDIRS += cmd internal
+GO_SUBDIRS += cmd internal pkg
 GO111MODULE = on
 -include build/makelib/golang.mk
 

--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package main generates managed resource method sets.
 package main
 
 import (

--- a/cmd/breakingChanges/main.go
+++ b/cmd/breakingChanges/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package main lints CRDs for breaking changes.
 package main
 
 import (
@@ -42,15 +43,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	new := &v1.CustomResourceDefinition{}
-	err = yaml.Unmarshal(newfile, new)
+	crd := &v1.CustomResourceDefinition{}
+	err = yaml.Unmarshal(newfile, crd)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	list := PrintFields(old.Spec.Versions[0].Schema.OpenAPIV3Schema, "", new.Spec.Versions[0].Schema.OpenAPIV3Schema)
-	for i := 0; i < len(list); i++ {
-		fmt.Println(list[i])
+	list := PrintFields(old.Spec.Versions[0].Schema.OpenAPIV3Schema, "", crd.Spec.Versions[0].Schema.OpenAPIV3Schema)
+	for i := range list {
+		fmt.Println(list[i]) //nolint:forbidigo // CLI tools are allowed to print their output.
 	}
 }
 

--- a/cmd/breakingChanges/main.go
+++ b/cmd/breakingChanges/main.go
@@ -56,7 +56,6 @@ func main() {
 
 // PrintFields function recursively traverses through the keys.
 func PrintFields(sch *v1.JSONSchemaProps, prefix string, newSchema *v1.JSONSchemaProps) []string {
-
 	var a []string
 
 	if len(sch.Properties) == 0 {

--- a/cmd/breakingChanges/main_test.go
+++ b/cmd/breakingChanges/main_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestBreakingChanges(t *testing.T) {
-
 	type args struct {
 		oldyaml *v1.JSONSchemaProps
 		newyaml *v1.JSONSchemaProps

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/crossplane/crossplane-tools
 
-go 1.23.6
+go 1.23.0
+
+toolchain go1.23.8
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0

--- a/internal/comments/comments.go
+++ b/internal/comments/comments.go
@@ -96,7 +96,7 @@ func ParseMarkers(comment string) Markers {
 // +key:value1
 // +key:value2
 //
-// Would be parsed as Markers{"key": []string{"value1", "value2"}}
+// Would be parsed as Markers{"key": []string{"value1", "value2"}}.
 func ParseMarkersWithPrefix(prefix, comment string) Markers {
 	m := map[string][]string{}
 

--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -54,7 +54,7 @@ const (
 )
 
 func matches(s *types.Struct, m Matcher) bool {
-	for i := 0; i < s.NumFields(); i++ {
+	for i := range s.NumFields() {
 		if m(s.Field(i)) {
 			return true
 		}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -78,7 +78,7 @@ func WithImportAliases(ia map[string]string) WriteOption {
 // same name is already defined for the object outside of the supplied filename.
 // Files will not be written if they would contain no methods.
 func WriteMethods(p *packages.Package, ms method.Set, file string, wo ...WriteOption) error {
-	opts := &options{Matches: func(o types.Object) bool { return true }}
+	opts := &options{Matches: func(_ types.Object) bool { return true }}
 	for _, fn := range wo {
 		fn(opts)
 	}
@@ -118,9 +118,7 @@ func WriteMethods(p *packages.Package, ms method.Set, file string, wo ...WriteOp
 		return nil
 	}
 
-	// gosec would prefer this to be written as 0600, but we're comfortable with
-	// it being world readable.
-	return errors.Wrap(os.WriteFile(file, b.Bytes(), 0o644), "cannot write Go file") // nolint:gosec
+	return errors.Wrap(os.WriteFile(file, b.Bytes(), 0o644), "cannot write Go file") //nolint:gosec // We're comfortable with this being world readable.
 }
 
 // ProducedNothing returns true if the supplied data is either not a valid Go

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -22,12 +22,11 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"os"
 
 	"github.com/dave/jennifer/jen"
 	"github.com/pkg/errors"
 	"golang.org/x/tools/go/packages"
-
-	"os"
 
 	"github.com/crossplane/crossplane-tools/internal/match"
 	"github.com/crossplane/crossplane-tools/internal/method"
@@ -66,7 +65,7 @@ func WithMatcher(m match.Object) WriteOption {
 // WithImportAliases configures a map of import paths to aliases that will be
 // used when generating code. For example if a generated method requires
 // "example.org/foo/bar" it may refer to that package as "foobar" by supplying
-// map[string]string{"example.org/foo/bar": "foobar"}
+// map[string]string{"example.org/foo/bar": "foobar"}.
 func WithImportAliases(ia map[string]string) WriteOption {
 	return func(o *options) {
 		o.ImportAliases = ia
@@ -121,8 +120,7 @@ func WriteMethods(p *packages.Package, ms method.Set, file string, wo ...WriteOp
 
 	// gosec would prefer this to be written as 0600, but we're comfortable with
 	// it being world readable.
-	return errors.Wrap(os.WriteFile(file, b.Bytes(), 0644), "cannot write Go file") // nolint:gosec
-
+	return errors.Wrap(os.WriteFile(file, b.Bytes(), 0o644), "cannot write Go file") // nolint:gosec
 }
 
 // ProducedNothing returns true if the supplied data is either not a valid Go

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -63,7 +63,7 @@ type Filter func(o types.Object, methodName string) bool
 func DefinedOutside(fs *token.FileSet, filename string) Filter {
 	return func(o types.Object, name string) bool {
 		s := types.NewMethodSet(types.NewPointer(o.Type()))
-		for i := 0; i < s.Len(); i++ {
+		for i := range s.Len() {
 			mo := s.At(i).Obj()
 			if mo.Name() != name {
 				continue
@@ -311,7 +311,7 @@ func NewSetRootProviderConfigReference(receiver, runtime string) New {
 
 // NewGetRootProviderConfigReference returns a NewMethod that writes a
 // GetProviderConfigReference method for the supplied Object to the supplied
-// file. file. Note that unlike NewGetProviderConfigReference the generated
+// file. Note that unlike NewGetProviderConfigReference the generated
 // method expects the ProviderConfigReference to be at the root of the struct,
 // not under its Spec field.
 func NewGetRootProviderConfigReference(receiver, runtime string) New {

--- a/internal/method/reference_processor.go
+++ b/internal/method/reference_processor.go
@@ -27,7 +27,7 @@ import (
 	"github.com/crossplane/crossplane-tools/internal/comments"
 )
 
-// Comment markers used by ReferenceProcessor
+// Comment markers used by ReferenceProcessor.
 const (
 	ReferenceTypeMarker               = "crossplane:generate:reference:type"
 	ReferenceExtractorMarker          = "crossplane:generate:reference:extractor"
@@ -35,9 +35,7 @@ const (
 	ReferenceSelectorFieldNameMarker  = "crossplane:generate:reference:selectorFieldName"
 )
 
-var (
-	regexFunctionCall = regexp.MustCompile(`((.+)\.)?([^.]+\(.*\))`)
-)
+var regexFunctionCall = regexp.MustCompile(`((.+)\.)?([^.]+\(.*\))`)
 
 // Reference is the internal representation that has enough information to let
 // us generate the resolver.

--- a/internal/method/resolver.go
+++ b/internal/method/resolver.go
@@ -83,16 +83,12 @@ func NewResolveReferences(traverser *xptypes.Traverser, receiver, clientPath, re
 	}
 }
 
-var cleaner = strings.NewReplacer(
-	"[]", "",
-	"*", "",
-)
-
 type resolutionCallFn func(parentFields ...string) *jen.Statement
 
 // encapsulate goes through the fields and encapsulates the final call with nil
 // guard and/or for loops.
 func encapsulate(index int, callFn resolutionCallFn, fields ...string) *jen.Statement {
+	cleaner := strings.NewReplacer("[]", "", "*", "")
 	if len(fields) <= index {
 		return callFn(fields...)
 	}

--- a/internal/method/resolver.go
+++ b/internal/method/resolver.go
@@ -21,11 +21,10 @@ import (
 	"go/types"
 	"strings"
 
+	"github.com/dave/jennifer/jen"
 	"github.com/pkg/errors"
 
 	xptypes "github.com/crossplane/crossplane-tools/internal/types"
-
-	"github.com/dave/jennifer/jen"
 )
 
 // NewResolveReferences returns a NewMethod that writes a ResolveReferences for

--- a/internal/method/resolver_test.go
+++ b/internal/method/resolver_test.go
@@ -20,14 +20,13 @@ import (
 	"fmt"
 	"testing"
 
-	xptypes "github.com/crossplane/crossplane-tools/internal/types"
-
 	"github.com/dave/jennifer/jen"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/packages/packagestest"
 
 	"github.com/crossplane/crossplane-tools/internal/comments"
+	xptypes "github.com/crossplane/crossplane-tools/internal/types"
 )
 
 const (

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -86,7 +86,7 @@ type Traverser struct {
 // constructing an error. But we keep that for future type and field processors.
 
 // Traverse traverser given type recursively and runs given processors.
-func (t *Traverser) Traverse(n *types.Named, cfg *ProcessorConfig, parentFields ...string) error { // nolint:gocyclo
+func (t *Traverser) Traverse(n *types.Named, cfg *ProcessorConfig, parentFields ...string) error { //nolint:gocyclo
 	// NOTE(muvaf): gocyclo is disabled due to repeated type checks.
 	if err := cfg.Named.Process(n, t.comments.For(n.Obj())); err != nil {
 		return errors.Wrapf(err, "type processors failed to run for type %s", n.Obj().Name())

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package types contains utilities for manipulating structs.
 package types
 
 import (
@@ -85,9 +86,8 @@ type Traverser struct {
 // NOTE(muvaf): We return an error but currently there isn't really anything
 // constructing an error. But we keep that for future type and field processors.
 
-// Traverse traverser given type recursively and runs given processors.
-func (t *Traverser) Traverse(n *types.Named, cfg *ProcessorConfig, parentFields ...string) error { //nolint:gocyclo
-	// NOTE(muvaf): gocyclo is disabled due to repeated type checks.
+// Traverse given type recursively and run given processors.
+func (t *Traverser) Traverse(n *types.Named, cfg *ProcessorConfig, parentFields ...string) error { //nolint:gocognit // This is complex, but pretty easy to read.
 	if err := cfg.Named.Process(n, t.comments.For(n.Obj())); err != nil {
 		return errors.Wrapf(err, "type processors failed to run for type %s", n.Obj().Name())
 	}
@@ -95,7 +95,7 @@ func (t *Traverser) Traverse(n *types.Named, cfg *ProcessorConfig, parentFields 
 	if !ok {
 		return nil
 	}
-	for i := 0; i < st.NumFields(); i++ {
+	for i := range st.NumFields() {
 		field := st.Field(i)
 		tag := st.Tag(i)
 		if err := cfg.Field.Process(n, field, tag, t.comments.For(field), parentFields...); err != nil {

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -35,7 +35,7 @@ func FromIntPtrValue(v *int64) string {
 
 // ToPtrValue adapts a ResolvedValue for use as a string pointer field.
 //
-// Deprecated: Use ptr.To from k8s.io/utils/ptr
+// Deprecated: Use ptr.To from k8s.io/utils/ptr.
 func ToPtrValue(v string) *string {
 	return ptr.To(v)
 }

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -1,3 +1,20 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package helpers contains utilities for working with pointers.
 package helpers
 
 import (


### PR DESCRIPTION
The Renovate PR for setup-go -> v5 doesn't like that there's a patch version specified in go.mod. I suspect because it's being run with a pretty old Go version (v1.18) in CI.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Closes https://github.com/crossplane/crossplane-tools/pull/76

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
