### PR TITLE
fix(angryjet): rename helpers to convert

### DIFF
--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -50,8 +50,8 @@ const (
 	ClientAlias  = "client"
 	ClientImport = "sigs.k8s.io/controller-runtime/pkg/client"
 
-	HelperAlias  = "helper"
-	HelperImport = "github.com/crossplane/crossplane-tools/pkg/helpers"
+	ConvertAlias  = "convert"
+	ConvertImport = "github.com/crossplane/crossplane-tools/pkg/convert"
 
 	RuntimeAlias  = "xpv1"
 	RuntimeImport = "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -234,14 +234,14 @@ func GenerateReferences(filename, header string, p *packages.Package) error {
 	comm := comments.In(p)
 
 	methods := method.Set{
-		"ResolveReferences": method.NewResolveReferences(types.NewTraverser(comm), receiver, ClientImport, ReferenceImport, HelperImport, PtrImport),
+		"ResolveReferences": method.NewResolveReferences(types.NewTraverser(comm), receiver, ClientImport, ReferenceImport, ConvertImport, PtrImport),
 	}
 
 	err := generate.WriteMethods(p, methods, filepath.Join(filepath.Dir(p.GoFiles[0]), filename),
 		generate.WithHeaders(header),
 		generate.WithImportAliases(map[string]string{
 			ClientImport:    ClientAlias,
-			HelperImport:    HelperAlias,
+			ConvertImport:   ConvertAlias,
 			ReferenceImport: ReferenceAlias,
 			PtrAlias:        PtrImport,
 		}),

--- a/internal/method/resolver.go
+++ b/internal/method/resolver.go
@@ -29,7 +29,7 @@ import (
 
 // NewResolveReferences returns a NewMethod that writes a ResolveReferences for
 // given managed resource, if needed.
-func NewResolveReferences(traverser *xptypes.Traverser, receiver, clientPath, referencePkgPath string, helpersPkgPath string, ptrPkgPath string) New {
+func NewResolveReferences(traverser *xptypes.Traverser, receiver, clientPath, referencePkgPath string, convertPkgPath string, ptrPkgPath string) New {
 	return func(f *jen.File, o types.Object) {
 		n, ok := o.Type().(*types.Named)
 		if !ok {
@@ -55,7 +55,7 @@ func NewResolveReferences(traverser *xptypes.Traverser, receiver, clientPath, re
 		for i, ref := range refs {
 			if ref.IsSlice {
 				hasMultiResolution = true
-				resolverCalls[i] = encapsulate(0, multiResolutionCall(ref, referencePkgPath, helpersPkgPath), ref.GoValueFieldPath...).Line()
+				resolverCalls[i] = encapsulate(0, multiResolutionCall(ref, referencePkgPath, convertPkgPath), ref.GoValueFieldPath...).Line()
 			} else {
 				hasSingleResolution = true
 				resolverCalls[i] = encapsulate(0, singleResolutionCall(ref, referencePkgPath, ptrPkgPath), ref.GoValueFieldPath...).Line()
@@ -162,7 +162,7 @@ func singleResolutionCall(ref Reference, referencePkgPath string, ptrPkgPath str
 	}
 }
 
-func multiResolutionCall(ref Reference, referencePkgPath string, helpersPkgPath string) resolutionCallFn {
+func multiResolutionCall(ref Reference, referencePkgPath string, convertPkgPath string) resolutionCallFn {
 	return func(fields ...string) *jen.Statement {
 		prefixPath := jen.Id(fields[0])
 		for i := 1; i < len(fields)-1; i++ {
@@ -181,8 +181,8 @@ func multiResolutionCall(ref Reference, referencePkgPath string, helpersPkgPath 
 		}
 
 		if ref.IsPointer {
-			setResolvedValues = currentValuePath.Clone().Op("=").Qual(helpersPkgPath, toPointersFunction).Call(jen.Id("mrsp").Dot("ResolvedValues"))
-			currentValuePath = jen.Qual(helpersPkgPath, fromPointersFunction).Call(currentValuePath)
+			setResolvedValues = currentValuePath.Clone().Op("=").Qual(convertPkgPath, toPointersFunction).Call(jen.Id("mrsp").Dot("ResolvedValues"))
+			currentValuePath = jen.Qual(convertPkgPath, fromPointersFunction).Call(currentValuePath)
 		}
 
 		return &jen.Statement{

--- a/internal/method/resolver_test.go
+++ b/internal/method/resolver_test.go
@@ -105,7 +105,7 @@ type Model struct {
 import (
 	"context"
 	client "example.org/client"
-	helpers "example.org/helpers"
+	convert "example.org/convert"
 	reference "example.org/reference"
 	v1beta11 "github.com/crossplane/provider-aws/apis/ec2/v1beta1"
 	v1beta1 "github.com/crossplane/provider-aws/apis/identity/v1beta1"
@@ -270,7 +270,7 @@ func (mg *Model) ResolveReferences(ctx context.Context, c client.Reader) error {
 	mg.Spec.ForProvider.SubnetIDRefs = mrsp.ResolvedReferences
 
 	mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
-		CurrentValues: helpers.FromPtrValues(mg.Spec.ForProvider.RouteTableIDs),
+		CurrentValues: convert.FromPtrValues(mg.Spec.ForProvider.RouteTableIDs),
 		Extract:       reference.ExternalName(),
 		References:    mg.Spec.ForProvider.RouteTableIDsRefs,
 		Selector:      mg.Spec.ForProvider.RouteTableIDsSelector,
@@ -282,7 +282,7 @@ func (mg *Model) ResolveReferences(ctx context.Context, c client.Reader) error {
 	if err != nil {
 		return errors.Wrap(err, "mg.Spec.ForProvider.RouteTableIDs")
 	}
-	mg.Spec.ForProvider.RouteTableIDs = helpers.ToPtrValues(mrsp.ResolvedValues)
+	mg.Spec.ForProvider.RouteTableIDs = convert.ToPtrValues(mrsp.ResolvedValues)
 	mg.Spec.ForProvider.RouteTableIDsRefs = mrsp.ResolvedReferences
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
@@ -320,7 +320,7 @@ func TestNewResolveReferences(t *testing.T) {
 		t.Error(err)
 	}
 	f := jen.NewFilePath("golang.org/fake/v1alpha1")
-	NewResolveReferences(xptypes.NewTraverser(comments.In(pkgs[0])), "mg", "example.org/client", "example.org/reference", "example.org/helpers", "k8s.io/utils/ptr")(f, pkgs[0].Types.Scope().Lookup("Model"))
+	NewResolveReferences(xptypes.NewTraverser(comments.In(pkgs[0])), "mg", "example.org/client", "example.org/reference", "example.org/convert", "k8s.io/utils/ptr")(f, pkgs[0].Types.Scope().Lookup("Model"))
 	if diff := cmp.Diff(generated, fmt.Sprintf("%#v", f)); diff != "" {
 		t.Errorf("NewResolveReferences(): -want, +got\n%s", diff)
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Follow up on #91, this rename was forgotten there.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've been running this for generating https://github.com/grafana/crossplane-provider-grafana/

I did have to update the generated code intermittently as I couldn't run `go mod tidy` or `make generate` because of this rename. Not sure if qualifies as a breaking change.
