### PR TITLE
Handle empty `ResolvedValue` as nil in reference resolvers and fix *float64 resolver generation

### DIFF
--- a/internal/method/resolver.go
+++ b/internal/method/resolver.go
@@ -58,7 +58,7 @@ func NewResolveReferences(traverser *xptypes.Traverser, receiver, clientPath, re
 				resolverCalls[i] = encapsulate(0, multiResolutionCall(ref, referencePkgPath, convertPkgPath), ref.GoValueFieldPath...).Line()
 			} else {
 				hasSingleResolution = true
-				resolverCalls[i] = encapsulate(0, singleResolutionCall(ref, referencePkgPath, ptrPkgPath), ref.GoValueFieldPath...).Line()
+				resolverCalls[i] = encapsulate(0, singleResolutionCall(ref, referencePkgPath, ptrPkgPath, convertPkgPath), ref.GoValueFieldPath...).Line()
 			}
 		}
 		var initStatements jen.Statement
@@ -113,8 +113,9 @@ func encapsulate(index int, callFn resolutionCallFn, fields ...string) *jen.Stat
 	}
 }
 
-func singleResolutionCall(ref Reference, referencePkgPath string, ptrPkgPath string) resolutionCallFn {
+func singleResolutionCall(ref Reference, referencePkgPath string, ptrPkgPath string, convertPkgPath string) resolutionCallFn {
 	return func(fields ...string) *jen.Statement {
+		pkgPath := ptrPkgPath
 		prefixPath := jen.Id(fields[0])
 		for i := 1; i < len(fields)-1; i++ {
 			prefixPath = prefixPath.Dot(fields[i])
@@ -129,10 +130,13 @@ func singleResolutionCall(ref Reference, referencePkgPath string, ptrPkgPath str
 		if ref.IsFloatPointer {
 			toPointerFunction = "ToFloatPtrValue"
 			fromPointerFunction = "FromFloatPtrValue"
+			pkgPath = convertPkgPath
 		}
 		if ref.IsPointer {
-			setResolvedValue = currentValuePath.Clone().Op("=").Qual(ptrPkgPath, toPointerFunction).Call(jen.Id("rsp").Dot("ResolvedValue"))
-			currentValuePath = jen.Qual(ptrPkgPath, fromPointerFunction).Call(currentValuePath, jen.Op(`""`))
+			setResolvedValue = jen.If(jen.Id("v").Op(":=").Id("rsp").Dot("ResolvedValue")).Op(";").Id("v").Op("!=").Lit("").Block(
+				jen.Add(prefixPath.Clone().Dot(fields[len(fields)-1]).Clone().Op("=").Qual(pkgPath, toPointerFunction).Call(jen.Id("v")))).Else().Block(
+				jen.Add(prefixPath.Clone().Dot(fields[len(fields)-1]).Clone().Op("=").Nil()))
+			currentValuePath = jen.Qual(pkgPath, fromPointerFunction).Call(currentValuePath, jen.Op(`""`))
 		}
 		return &jen.Statement{
 			jen.List(jen.Id("rsp"), jen.Err()).Op("=").Id("r").Dot("Resolve").Call(


### PR DESCRIPTION
### Description of your changes

This PR handles two things:
- Restoring the expected behavior for optional pointer fields `*string` fields in the generated reference resolver code.
- Fixing the reference resolvers of the `*float64` fields. Now they use the wrong import package. They use the `k8s.io/utils/ptr`, but the functions are not there. They are in the `pkg/convert` package of the crossplane-tools.

### 1. Restoring the expected behavior for optional pointer fields *string

With the upgrade to crossplane-runtime `v1.19.0` in the providers, reference resolver generation shifted from using `reference.ToPtrValue()` to `ptr.To()` from `k8s.io/utils/ptr`. This introduced an unintended behavioral change:

Previously, "" string values were interpreted as nil via:

```go
func ToPtrValue(v string) *string {
	if v == "" {
		return nil
	}
	return &v
}
```

Now, ptr.To() always returns a pointer, even for empty strings:

```go
func To[T any](v T) *T {
	return &v
}
```

This causes `*string` to be populated with empty values ("") instead of remaining nil, which breaks assumptions in many providers.

This PR modifies the resolver generation logic for *string fields: `check rsp.ResolvedValue != ""` before assigning the pointer. The generated code:

```go
if v := rsp.ResolvedValue; v != "" {
    mg.Spec.ForProvider.Network = ptr.To(v)
} else {
    mg.Spec.ForProvider.Network = nil
}
```

This approach ensures compatibility with the pre-v1.19.0 behavior and prevents accidental setting of non-nil empty or zero values.

### 2. Fixing the reference resolvers of the `*float64` fields

In the current generation, the reference resolvers for the `*float64` fields use the `k8s.io/utils/ptr` library, but the referenced functions are not in this library. These functions, `ToFloatPtrValue` and `FromFloatPtrValue`, are in `github.com/crossplane/crossplane-tools/pkg/convert` package. This PR fixes the wrong reference.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in the provider-upjet-gcp and provider-upjet-azuread locally.

[contribution process]: https://git.io/fj2m9
