### PR TITLE
build: use a subfolder in the releases S3 bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PLATFORMS ?= linux_amd64 darwin_amd64
 # to run a target until the include commands succeeded.
 -include build/makelib/common.mk
 
-S3_BUCKET ?= crossplane.releases
+S3_BUCKET ?= crossplane.releases/$(PROJECT_NAME)
 -include build/makelib/output.mk
 
 # Set a sane default so that the nprocs calculation below is less noisy on the initial


### PR DESCRIPTION
### Description of your changes

This PR simply updates the makefile variable `S3_BUCKET` to use a subfolder, as hinted at in https://github.com/crossplane/build/blob/main/README.md#quickstart. Looks like only a couple projects have done this, but it appears to be working successfully, for example https://releases.crossplane.io/oam/. 

This should restrict all of the artifacts from this crossplane-tools repo to that subfolder, instead of overwriting core crossplane artifacts as described in:

* https://github.com/crossplane/crossplane-tools/issues/99 

Fixes #99

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

We'll see if any issues come up in the CI for this PR. Publishing/promoting only happens upstream, so I think we may not be able to really test this until merging. Anything is better than overwriting upstream core Crossplane though 😂 

[contribution process]: https://git.io/fj2m9
