### PR TITLE
angryjet: generate Crossplane V2 interface methods

### DIFF
--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -36,6 +36,9 @@ const (
 	NameProviderConfigStatus = "ProviderConfigStatus"
 	NameProviderConfigUsage  = "ProviderConfigUsage"
 	NameItems                = "Items"
+
+	NameTypedProviderConfigUsage = "TypedProviderConfigUsage"
+	NameResourceV2Spec           = "ManagedResourceSpec"
 )
 
 // Field type suffixes.
@@ -51,6 +54,9 @@ const (
 	TypeSuffixProviderConfigSpec   = "github.com/crossplane/crossplane-runtime/apis/common/v1.ProviderConfigSpec"
 	TypeSuffixProviderConfigStatus = "github.com/crossplane/crossplane-runtime/apis/common/v1.ProviderConfigStatus"
 	TypeSuffixProviderConfigUsage  = "github.com/crossplane/crossplane-runtime/apis/common/v1.ProviderConfigUsage"
+
+	TypeSuffixProviderConfigUsageV2 = "github.com/crossplane/crossplane-runtime/apis/common/v2.TypedProviderConfigUsage"
+	TypeSuffixResourceV2Spec        = "github.com/crossplane/crossplane-runtime/apis/common/v2.ManagedResourceSpec"
 )
 
 func matches(s *types.Struct, m Matcher) bool {
@@ -182,6 +188,10 @@ func IsStatus() Matcher { return IsTypeNamed(NameStatus, TypeSuffixStatus) }
 // appears to be a Crossplane managed resource spec.
 func IsResourceSpec() Matcher { return IsTypeNamed(TypeSuffixResourceSpec, NameResourceSpec) }
 
+// IsResourceV2Spec returns a Matcher that returns true if the supplied field
+// appears to be a Crossplane managed resource spec.
+func IsResourceV2Spec() Matcher { return IsTypeNamed(TypeSuffixResourceV2Spec, NameResourceV2Spec) }
+
 // IsResourceStatus returns a Matcher that returns true if the supplied field
 // appears to be a Crossplane managed resource status.
 func IsResourceStatus() Matcher { return IsTypeNamed(TypeSuffixResourceStatus, NameResourceStatus) }
@@ -202,6 +212,12 @@ func IsProviderConfigStatus() Matcher {
 // field appears to be a Crossplane provider config usage.
 func IsProviderConfigUsage() Matcher {
 	return IsTypeNamed(TypeSuffixProviderConfigUsage, NameProviderConfigUsage)
+}
+
+// IsTypedProviderConfigUsage returns a Matcher that returns true if the supplied
+// field appears to be a Crossplane provider config usage with typed ref.
+func IsTypedProviderConfigUsage() Matcher {
+	return IsTypeNamed(TypeSuffixProviderConfigUsageV2, NameTypedProviderConfigUsage)
 }
 
 // IsItems returns a Matcher that returns true if the supplied field appears to

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -45,6 +45,23 @@ func Managed() Object {
 	}
 }
 
+// ManagedV2 returns an Object matcher that returns true if the supplied Object is
+// a v2-style Crossplane managed resource.
+func ManagedV2() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsObjectMeta().And(fields.IsEmbedded()),
+			fields.IsSpec().And(fields.HasFieldThat(
+				fields.IsResourceV2Spec().And(fields.IsEmbedded()),
+			)),
+			fields.IsStatus().And(fields.HasFieldThat(
+				fields.IsResourceStatus().And(fields.IsEmbedded()),
+			)),
+		)
+	}
+}
+
 // ManagedList returns an Object matcher that returns true if the supplied
 // Object is a list of Crossplane managed resource.
 func ManagedList() Object {
@@ -56,6 +73,26 @@ func ManagedList() Object {
 				fields.IsObjectMeta().And(fields.IsEmbedded()),
 				fields.IsSpec().And(fields.HasFieldThat(
 					fields.IsResourceSpec().And(fields.IsEmbedded()),
+				)),
+				fields.IsStatus().And(fields.HasFieldThat(
+					fields.IsResourceStatus().And(fields.IsEmbedded()),
+				)),
+			)),
+		)
+	}
+}
+
+// ManagedListV2 returns an Object matcher that returns true if the supplied
+// Object is a list of Crossplane managed resource.
+func ManagedListV2() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsItems().And(fields.IsSlice()).And(fields.HasFieldThat(
+				fields.IsTypeMeta().And(fields.IsEmbedded()),
+				fields.IsObjectMeta().And(fields.IsEmbedded()),
+				fields.IsSpec().And(fields.HasFieldThat(
+					fields.IsResourceV2Spec().And(fields.IsEmbedded()),
 				)),
 				fields.IsStatus().And(fields.HasFieldThat(
 					fields.IsResourceStatus().And(fields.IsEmbedded()),
@@ -92,6 +129,18 @@ func ProviderConfigUsage() Object {
 	}
 }
 
+// TypedProviderConfigUsage returns an Object matcher that returns true if the supplied
+// Object is a Crossplane v2 style ProviderConfigUsage.
+func TypedProviderConfigUsage() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsObjectMeta().And(fields.IsEmbedded()),
+			fields.IsTypedProviderConfigUsage().And(fields.IsEmbedded()),
+		)
+	}
+}
+
 // ProviderConfigUsageList returns an Object matcher that returns true if the
 // supplied Object is a list of Crossplane provider config usages.
 func ProviderConfigUsageList() Object {
@@ -102,6 +151,21 @@ func ProviderConfigUsageList() Object {
 				fields.IsTypeMeta().And(fields.IsEmbedded()),
 				fields.IsObjectMeta().And(fields.IsEmbedded()),
 				fields.IsProviderConfigUsage().And(fields.IsEmbedded()),
+			)),
+		)
+	}
+}
+
+// TypedProviderConfigUsageList returns an Object matcher that returns true if the
+// supplied Object is a list of Crossplane provider config usages.
+func TypedProviderConfigUsageList() Object {
+	return func(o types.Object) bool {
+		return fields.Has(o,
+			fields.IsTypeMeta().And(fields.IsEmbedded()),
+			fields.IsItems().And(fields.IsSlice()).And(fields.HasFieldThat(
+				fields.IsTypeMeta().And(fields.IsEmbedded()),
+				fields.IsObjectMeta().And(fields.IsEmbedded()),
+				fields.IsTypedProviderConfigUsage().And(fields.IsEmbedded()),
 			)),
 		)
 	}

--- a/internal/method/method.go
+++ b/internal/method/method.go
@@ -142,6 +142,28 @@ func NewGetProviderConfigReference(receiver, runtime string) New {
 	}
 }
 
+// NewSetTypedProviderConfigReference returns a NewMethod that writes a SetProviderConfigReference
+// method for the supplied Object to the supplied file.
+func NewSetTypedProviderConfigReference(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("SetProviderConfigReference of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetProviderConfigReference").Params(jen.Id("r").Op("*").Qual(runtime, "ProviderConfigReference")).Block(
+			jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderConfigReference").Op("=").Id("r"),
+		)
+	}
+}
+
+// NewGetTypedProviderConfigReference returns a NewMethod that writes a GetProviderConfigReference
+// method for the supplied Object to the supplied file.
+func NewGetTypedProviderConfigReference(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetProviderConfigReference of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetProviderConfigReference").Params().Op("*").Qual(runtime, "ProviderConfigReference").Block(
+			jen.Return(jen.Id(receiver).Dot(fields.NameSpec).Dot("ProviderConfigReference")),
+		)
+	}
+}
+
 // NewSetWriteConnectionSecretToReference returns a NewMethod that writes a
 // SetWriteConnectionSecretToReference method for the supplied Object to the
 // supplied file.
@@ -356,6 +378,34 @@ func NewProviderConfigUsageGetItems(receiver, resource string) New {
 				jen.Id("items").Index(jen.Id("i")).Op("=").Op("&").Id(receiver).Dot("Items").Index(jen.Id("i")),
 			),
 			jen.Return(jen.Id("items")),
+		)
+	}
+}
+
+// NewSetRootProviderConfigTypedReference returns a NewMethod that writes a
+// SetProviderConfigTypedReference method for the supplied Object to the supplied
+// file. Note that unlike NewSetProviderConfigTypedReference the generated method
+// expects the ProviderConfigReference to be at the root of the struct, not
+// under its Spec field.
+func NewSetRootProviderConfigTypedReference(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("SetProviderConfigReference of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("SetProviderConfigReference").Params(jen.Id("r").Qual(runtime, "ProviderConfigReference")).Block(
+			jen.Id(receiver).Dot("ProviderConfigReference").Op("=").Id("r"),
+		)
+	}
+}
+
+// NewGetRootProviderConfigTypedReference returns a NewMethod that writes a
+// GetProviderConfigTypedReference method for the supplied Object to the supplied
+// file. Note that unlike NewGetProviderConfigTypedReference the generated
+// method expects the ProviderConfigReference to be at the root of the struct,
+// not under its Spec field.
+func NewGetRootProviderConfigTypedReference(receiver, runtime string) New {
+	return func(f *jen.File, o types.Object) {
+		f.Commentf("GetProviderConfigReference of this %s.", o.Name())
+		f.Func().Params(jen.Id(receiver).Op("*").Id(o.Name())).Id("GetProviderConfigReference").Params().Qual(runtime, "ProviderConfigReference").Block(
+			jen.Return(jen.Id(receiver).Dot("ProviderConfigReference")),
 		)
 	}
 }


### PR DESCRIPTION
### Description of your changes

Generate Crossplane V2 interface methods to facilitate namespace-scoped MRs.

- `SetProviderConfigReference` and `GetProviderConfigReference` methods to return typed references for namespaced MRs.
-  `SetProviderConfigReference` and `SetProviderConfigReference` for typed provider config usages.
- `GetWriteConnectionSecretToReference` and `SetWriteConnectionSecretToReference` with local secret refs.
- `ResolveReferences` methods are now generated with namespace-aware reference/selector resolvers.
-  Remove `GetPublishConnectionDetailsTo` and `SetPublishConnectionDetailsTo` in accordance with ESS support removal.
- Remove `GetDeletionPolicy` and `SetDeletionPolicy` in accordance with removal of deletion policy in V2 managed resources.
I have:
- 

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Generated and tested V2 providers. PRs will be linked.
- provider-upjet-aws
- provider-upjet-azure
- provider-upjet-gcp


[contribution process]: https://git.io/fj2m9
