### PR TITLE
replace crossplane-runtime import path references with v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Args:
 ```
 
 [Crossplane]: https://crossplane.io
-[`resource.Managed`]: https://godoc.org/github.com/crossplane/crossplane-runtime/pkg/resource#Managed
-[`ResourceSpec`]: https://godoc.org/github.com/crossplane/crossplane-runtime/apis/common/v1#ResourceSpec
-[`ResourceStatus`]: https://godoc.org/github.com/crossplane/crossplane-runtime/apis/common/v1#ResourceStatus
+[`resource.Managed`]: https://godoc.org/github.com/crossplane/crossplane-runtime/v2/pkg/resource#Managed
+[`ResourceSpec`]: https://godoc.org/github.com/crossplane/crossplane-runtime/v2/apis/common/v1#ResourceSpec
+[`ResourceStatus`]: https://godoc.org/github.com/crossplane/crossplane-runtime/v2/apis/common/v1#ResourceStatus
 [Provider Development Guide]: https://github.com/crossplane/crossplane/blob/master/contributing/guide-provider-development.md#defining-resource-kinds

--- a/cmd/angryjet/main.go
+++ b/cmd/angryjet/main.go
@@ -51,13 +51,13 @@ const (
 	ClientImport = "sigs.k8s.io/controller-runtime/pkg/client"
 
 	RuntimeAlias  = "xpv1"
-	RuntimeImport = "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	RuntimeImport = "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 
 	ResourceAlias  = "resource"
-	ResourceImport = "github.com/crossplane/crossplane-runtime/pkg/resource"
+	ResourceImport = "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 
 	ReferenceAlias  = "reference"
-	ReferenceImport = "github.com/crossplane/crossplane-runtime/pkg/reference"
+	ReferenceImport = "github.com/crossplane/crossplane-runtime/v2/pkg/reference"
 )
 
 func main() {

--- a/internal/fields/fields.go
+++ b/internal/fields/fields.go
@@ -49,14 +49,14 @@ const (
 	TypeSuffixSpec                 = NameSpec
 	TypeSuffixSpecTemplate         = NameSpecTemplate
 	TypeSuffixStatus               = NameStatus
-	TypeSuffixResourceSpec         = "github.com/crossplane/crossplane-runtime/apis/common/v1.ResourceSpec"
-	TypeSuffixResourceStatus       = "github.com/crossplane/crossplane-runtime/apis/common/v1.ResourceStatus"
-	TypeSuffixProviderConfigSpec   = "github.com/crossplane/crossplane-runtime/apis/common/v1.ProviderConfigSpec"
-	TypeSuffixProviderConfigStatus = "github.com/crossplane/crossplane-runtime/apis/common/v1.ProviderConfigStatus"
-	TypeSuffixProviderConfigUsage  = "github.com/crossplane/crossplane-runtime/apis/common/v1.ProviderConfigUsage"
+	TypeSuffixResourceSpec         = "github.com/crossplane/crossplane-runtime/v2/apis/common/v1.ResourceSpec"
+	TypeSuffixResourceStatus       = "github.com/crossplane/crossplane-runtime/v2/apis/common/v1.ResourceStatus"
+	TypeSuffixProviderConfigSpec   = "github.com/crossplane/crossplane-runtime/v2/apis/common/v1.ProviderConfigSpec"
+	TypeSuffixProviderConfigStatus = "github.com/crossplane/crossplane-runtime/v2/apis/common/v1.ProviderConfigStatus"
+	TypeSuffixProviderConfigUsage  = "github.com/crossplane/crossplane-runtime/v2/apis/common/v1.ProviderConfigUsage"
 
-	TypeSuffixProviderConfigUsageV2 = "github.com/crossplane/crossplane-runtime/apis/common/v2.TypedProviderConfigUsage"
-	TypeSuffixResourceV2Spec        = "github.com/crossplane/crossplane-runtime/apis/common/v2.ManagedResourceSpec"
+	TypeSuffixProviderConfigUsageV2 = "github.com/crossplane/crossplane-runtime/v2/apis/common/v2.TypedProviderConfigUsage"
+	TypeSuffixResourceV2Spec        = "github.com/crossplane/crossplane-runtime/v2/apis/common/v2.ManagedResourceSpec"
 )
 
 func matches(s *types.Struct, m Matcher) bool {


### PR DESCRIPTION
### Description of your changes

With https://github.com/crossplane/crossplane/issues/6656, crossplane-runtime go module was bumped to `v2`.

This PR replaces the import paths of crossplane-runtime to `v2` in the generated functions.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
- unit tests
- provider-upjet-gcp
- provider-upjet-azuread

