### PR TITLE
ci: pin GitHub Actions to SHAs and tidy Go modules via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
### Description of your changes

This PR updates the Renovate config to add `helpers:pinGitHubActionDigests` so Renovate pins every action to an immutable commit SHA and keeps it current as upstream tags move. I noticed this while I was recently in this repo and it will be a good improvement to overall repo security hygiene. 

While we're here, also add the `gomodTidy` and `gomodUpdateImportPaths` `postUpdateOptions` so Renovate tidies `go.mod` and `go.sum` and rewrites import paths on major module bumps, avoiding check-diff failures on its Go dependency PRs.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I'll check on Renovate's next run after this is merged, but I have some confidence this should work since we're already doing it in https://github.com/crossplane-contrib/function-kro/blob/main/renovate.json.

[contribution process]: https://git.io/fj2m9
